### PR TITLE
Optimized memory usage

### DIFF
--- a/src/contrib/test262.rs
+++ b/src/contrib/test262.rs
@@ -296,8 +296,7 @@ fn run_safe(file: String) {
         Err(error) => {
             let _scope = env.new_local_scope();
             
-            let error = error.as_runtime(&mut env);
-            let error = error.as_local(&env);
+            let error = error.as_runtime(&mut env).as_value(&env);
             
             let error = if let Ok(error) = error.to_string(&mut env) {
                 let mut error = error.to_string();

--- a/src/rt/boolean.rs
+++ b/src/rt/boolean.rs
@@ -1,5 +1,4 @@
 use rt::{JsItem, JsEnv, JsValue, JsHandle};
-use gc::Local;
 
 pub struct JsBoolean {
     value: bool
@@ -14,15 +13,15 @@ impl JsBoolean {
 }
 
 impl JsItem for JsBoolean {
-    fn as_value(&self, env: &JsEnv) -> Local<JsValue> {
-        env.new_bool(self.value)
+    fn as_value(&self) -> JsValue {
+        JsValue::new_bool(self.value)
     }
     
-    fn has_prototype(&self, _: &JsEnv) -> bool {
+    fn has_prototype(&self) -> bool {
         true
     }
     
-    fn prototype(&self, env: &JsEnv) -> Option<Local<JsValue>> {
-        Some(env.handle(JsHandle::Boolean).as_value(env))
+    fn prototype(&self, env: &JsEnv) -> Option<JsValue> {
+        Some(env.handle(JsHandle::Boolean).as_value())
     }
 }

--- a/src/rt/env/boolean.rs
+++ b/src/rt/env/boolean.rs
@@ -1,24 +1,23 @@
 use ::{JsResult, JsError};
 use rt::{JsEnv, JsArgs, JsValue, JsFnMode, JsItem, JsType, JsString};
-use gc::*;
 use syntax::token::name;
 
 // 15.6.1 The Boolean Constructor Called as a Function
 // 15.6.2 The Boolean Constructor
-pub fn Boolean_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Boolean_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = if args.argc > 0 {
         args.arg(env, 0).to_boolean()
     } else {
         false
     };
     
-    let arg = env.new_bool(arg);
+    let arg = JsValue::new_bool(arg);
     
     if mode.construct() {
         let this_arg = args.this(env);
-        let mut this = this_arg.unwrap_object(env);
+        let mut this = this_arg.unwrap_object();
         
-        this.set_class(env, Some(name::BOOLEAN_CLASS));
+        this.set_class(Some(name::BOOLEAN_CLASS));
         this.set_value(arg);
         
         Ok(this_arg)
@@ -27,11 +26,11 @@ pub fn Boolean_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsR
     }
 }
 
-fn get_bool_value(env: &mut JsEnv, this: Local<JsValue>) -> JsResult<bool> {
+fn get_bool_value(env: &mut JsEnv, this: JsValue) -> JsResult<bool> {
     match this.ty() {
         JsType::Boolean => Ok(this.unwrap_bool()),
-        JsType::Object if this.class(env) == Some(name::BOOLEAN_CLASS) => {
-            let this = this.unwrap_object(env);
+        JsType::Object if this.class() == Some(name::BOOLEAN_CLASS) => {
+            let this = this.unwrap_object();
             
             Ok(this.value(env).unwrap_bool())
         }
@@ -40,19 +39,19 @@ fn get_bool_value(env: &mut JsEnv, this: Local<JsValue>) -> JsResult<bool> {
 }
 
 // 15.6.4.3 Boolean.prototype.valueOf ( )
-pub fn Boolean_valueOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Boolean_valueOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let this_arg = args.this(env);
     let value = try!(get_bool_value(env, this_arg));
     
-    Ok(env.new_bool(value))
+    Ok(JsValue::new_bool(value))
 }
 
 // 15.6.4.2 Boolean.prototype.toString ( )
-pub fn Boolean_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Boolean_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let this_arg = args.this(env);
     let value = try!(get_bool_value(env, this_arg));
     
     let result = if value { "true" } else { "false" };
     
-    Ok(JsString::from_str(env, result).as_value(env))
+    Ok(JsString::from_str(env, result).as_value())
 }

--- a/src/rt/env/console.rs
+++ b/src/rt/env/console.rs
@@ -1,12 +1,11 @@
 use ::JsResult;
 use rt::{JsEnv, JsArgs, JsValue, JsFnMode};
-use gc::*;
 
 // TODO #65
-pub fn console_log(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn console_log(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(args.arg(env, 0).to_string(env)).to_string();
     
     println!("{}", string);
     
-    Ok(env.new_undefined())
+    Ok(JsValue::new_undefined())
 }

--- a/src/rt/env/error.rs
+++ b/src/rt/env/error.rs
@@ -1,28 +1,27 @@
 use ::{JsResult, JsError};
 use rt::{JsEnv, JsArgs, JsValue, JsFnMode, JsItem, JsType, JsString};
-use gc::*;
 use syntax::token::name;
 
-pub fn Error_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Error_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     if !mode.construct() {
         let target_args = args.args(env);
         return args.function(env).construct(env, target_args);
     }
     
     let this = try!(args.this(env).to_object(env));
-    let mut this_obj = this.unwrap_object(env);
-    this_obj.set_class(env, Some(name::ERROR_CLASS));
+    let mut this_obj = this.unwrap_object();
+    this_obj.set_class(Some(name::ERROR_CLASS));
     
     let message = args.arg(env, 0);
     if !message.is_undefined() {
-        let message = try!(message.to_string(env)).as_value(env);
+        let message = try!(message.to_string(env)).as_value();
         try!(this_obj.put(env, name::MESSAGE, message, true));
     }
     
     Ok(this)
 }
 
-pub fn Error_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Error_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let this = args.this(env);
     if this.ty() != JsType::Object {
         Err(JsError::new_type(env, ::errors::TYPE_INVALID))
@@ -50,6 +49,6 @@ pub fn Error_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResul
             JsString::from_str(env, &result)
         };
         
-        Ok(result.as_value(env))
+        Ok(result.as_value())
     }
 }

--- a/src/rt/env/json/mod.rs
+++ b/src/rt/env/json/mod.rs
@@ -1,6 +1,5 @@
 use ::JsResult;
 use rt::{JsEnv, JsArgs, JsValue, JsFnMode};
-use gc::*;
 use syntax::reader::StringReader;
 use self::writer::JsonWriter;
 
@@ -9,7 +8,7 @@ mod parser;
 mod writer;
 
 // 15.12.2 parse ( text [ , reviver ] )
-pub fn JSON_parse(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn JSON_parse(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(args.arg(env, 0).to_string(env)).to_string();
     
     let mut reader = StringReader::new("(json)", &string);
@@ -21,6 +20,6 @@ pub fn JSON_parse(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Lo
 }
 
 // 15.12.3 stringify ( value [ , replacer [ , space ] ] )
-pub fn JSON_stringify(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn JSON_stringify(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     try!(JsonWriter::new(env, mode, args)).write()
 }

--- a/src/rt/env/json/parser.rs
+++ b/src/rt/env/json/parser.rs
@@ -2,7 +2,6 @@ use syntax::Name;
 use ::{JsResult, JsError};
 use rt::{JsEnv, JsValue, JsDescriptor, JsString, JsItem};
 use rt::env::json::lexer::{Lexer, Token, Lit};
-use gc::Local;
 
 pub struct Parser<'a> {
     lexer: &'a mut Lexer<'a>,
@@ -59,7 +58,7 @@ impl<'a> Parser<'a> {
         Err(JsError::Parse(message.to_string()))
     }
     
-    pub fn parse_json(env: &'a mut JsEnv, lexer: &'a mut Lexer<'a>) -> JsResult<Local<JsValue>> {
+    pub fn parse_json(env: &'a mut JsEnv, lexer: &'a mut Lexer<'a>) -> JsResult<JsValue> {
         let mut parser = Parser {
             lexer: lexer,
             env: env
@@ -74,14 +73,14 @@ impl<'a> Parser<'a> {
         }
     }
     
-    fn parse_value(&mut self) -> JsResult<Local<JsValue>> {
+    fn parse_value(&mut self) -> JsResult<JsValue> {
         match try!(self.next()) {
             Token::Literal(lit) => {
                 match lit {
-                    Lit::Null => Ok(self.env.new_null()),
-                    Lit::Boolean(value) => Ok(self.env.new_bool(value)),
-                    Lit::String(value) => Ok(JsString::from_str(self.env, &value).as_value(self.env)),
-                    Lit::Number(value) => Ok(self.env.new_number(value))
+                    Lit::Null => Ok(JsValue::new_null()),
+                    Lit::Boolean(value) => Ok(JsValue::new_bool(value)),
+                    Lit::String(value) => Ok(JsString::from_str(self.env, &value).as_value()),
+                    Lit::Number(value) => Ok(JsValue::new_number(value))
                 }
             }
             Token::OpenBrace => self.parse_object(),
@@ -90,7 +89,7 @@ impl<'a> Parser<'a> {
         }
     }
     
-    fn parse_object(&mut self) -> JsResult<Local<JsValue>> {
+    fn parse_object(&mut self) -> JsResult<JsValue> {
         let mut object = self.env.create_object();
         
         if !try!(self.consume(Token::CloseBrace)) {
@@ -114,10 +113,10 @@ impl<'a> Parser<'a> {
             }
         }
         
-        Ok(object.as_value(self.env))
+        Ok(object.as_value())
     }
     
-    fn parse_array(&mut self) -> JsResult<Local<JsValue>> {
+    fn parse_array(&mut self) -> JsResult<JsValue> {
         let mut array = self.env.create_array();
         let mut offset = 0;
         
@@ -136,6 +135,6 @@ impl<'a> Parser<'a> {
             }
         }
     
-        Ok(array.as_value(self.env))
+        Ok(array.as_value())
     }
 }

--- a/src/rt/env/math.rs
+++ b/src/rt/env/math.rs
@@ -2,88 +2,87 @@ extern crate rand;
 
 use ::JsResult;
 use rt::{JsEnv, JsArgs, JsValue, JsFnMode, JsType};
-use gc::*;
 use std::f64;
 use self::rand::random;
 
 // 15.8.2.1 abs (x)
-pub fn Math_abs(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_abs(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
-    Ok(env.new_number(arg.abs()))
+    Ok(JsValue::new_number(arg.abs()))
 }
 
 // 15.8.2.2 acos (x)
-pub fn Math_acos(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_acos(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.acos()))
+    Ok(JsValue::new_number(arg.acos()))
 }
 
 // 15.8.2.3 asin (x)
-pub fn Math_asin(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_asin(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.asin()))
+    Ok(JsValue::new_number(arg.asin()))
 }
 
 // 15.8.2.4 atan (x)
-pub fn Math_atan(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_atan(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.atan()))
+    Ok(JsValue::new_number(arg.atan()))
 }
 
 // 15.8.2.5 atan2 (y, x)
-pub fn Math_atan2(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_atan2(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let y = try!(args.arg(env, 0).to_number(env));
     let x = try!(args.arg(env, 1).to_number(env));
     
-    Ok(env.new_number(y.atan2(x)))
+    Ok(JsValue::new_number(y.atan2(x)))
 }
 
 // 15.8.2.6 ceil (x)
-pub fn Math_ceil(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_ceil(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.ceil()))
+    Ok(JsValue::new_number(arg.ceil()))
 }
 
 // 15.8.2.7 cos (x)
-pub fn Math_cos(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_cos(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.cos()))
+    Ok(JsValue::new_number(arg.cos()))
 }
 
 // 15.8.2.8 exp (x)
-pub fn Math_exp(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_exp(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.exp()))
+    Ok(JsValue::new_number(arg.exp()))
 }
 
 // 15.8.2.9 floor (x)
-pub fn Math_floor(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_floor(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.floor()))
+    Ok(JsValue::new_number(arg.floor()))
 }
 
 // 15.8.2.10 log (x)
-pub fn Math_log(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_log(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.ln()))
+    Ok(JsValue::new_number(arg.ln()))
 }
 
 // 15.8.2.11 max ( [ value1 [ , value2 [ , … ] ] ] )
-pub fn Math_max(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_max(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let mut result = None;
     
     for i in 0..args.argc {
         let arg = args.arg(env, i);
         if arg.ty() == JsType::Number && arg.unwrap_number().is_nan() {
-            return Ok(env.new_number(f64::NAN));
+            return Ok(JsValue::new_number(f64::NAN));
         }
         
         if let Some(last) = result {
@@ -97,18 +96,18 @@ pub fn Math_max(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Loca
     
     Ok(match result {
         Some(result) => result,
-        _ => env.new_number(f64::NEG_INFINITY)
+        _ => JsValue::new_number(f64::NEG_INFINITY)
     })
 }
 
 // 15.8.2.12 min ( [ value1 [ , value2 [ , … ] ] ] )
-pub fn Math_min(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_min(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let mut result = None;
     
     for i in 0..args.argc {
         let arg = args.arg(env, i);
         if arg.ty() == JsType::Number && arg.unwrap_number().is_nan() {
-            return Ok(env.new_number(f64::NAN));
+            return Ok(JsValue::new_number(f64::NAN));
         }
         
         if let Some(last) = result {
@@ -122,12 +121,12 @@ pub fn Math_min(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Loca
     
     Ok(match result {
         Some(result) => result,
-        _ => env.new_number(f64::INFINITY)
+        _ => JsValue::new_number(f64::INFINITY)
     })
 }
 
 // 15.8.2.13 pow (x, y)
-pub fn Math_pow(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_pow(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let x = try!(args.arg(env, 0).to_number(env));
     let y = try!(args.arg(env, 1).to_number(env));
     
@@ -145,16 +144,16 @@ pub fn Math_pow(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Loca
         x.powf(y)
     };
     
-    Ok(env.new_number(result))
+    Ok(JsValue::new_number(result))
 }
 
 // 15.8.2.14 random ( )
-pub fn Math_random(env: &mut JsEnv, _mode: JsFnMode, _args: JsArgs) -> JsResult<Local<JsValue>> {
-    Ok(env.new_number(random::<f64>()))
+pub fn Math_random(_env: &mut JsEnv, _mode: JsFnMode, _args: JsArgs) -> JsResult<JsValue> {
+    Ok(JsValue::new_number(random::<f64>()))
 }
 
 // 15.8.2.15 round (x)
-pub fn Math_round(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_round(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
     let result = if arg.is_finite() {
@@ -182,26 +181,26 @@ pub fn Math_round(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Lo
         arg
     };
     
-    Ok(env.new_number(result))
+    Ok(JsValue::new_number(result))
 }
 
 // 15.8.2.16 sin (x)
-pub fn Math_sin(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_sin(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.sin()))
+    Ok(JsValue::new_number(arg.sin()))
 }
 
 // 15.8.2.17 sqrt (x)
-pub fn Math_sqrt(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_sqrt(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.sqrt()))
+    Ok(JsValue::new_number(arg.sqrt()))
 }
 
 // 15.8.2.18 tan (x)
-pub fn Math_tan(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_tan(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.tan()))
+    Ok(JsValue::new_number(arg.tan()))
 }

--- a/src/rt/env/mod.rs
+++ b/src/rt/env/mod.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 
-use rt::{JsEnv, JsObject, JsFunction, JsFn, JsFnRef, JsValue, JsDescriptor, JsItem};
+use rt::{JsEnv, JsObject, JsFunction, JsFn, JsValue, JsDescriptor, JsItem};
 use rt::{JsStoreType, JsScope, JsString, JsHandle};
 use ::JsResult;
 use syntax::Name;
@@ -39,7 +39,7 @@ mod json;
 macro_rules! function {
     ( $target:expr , $name:expr , $function:ident , $arity:expr , $env:expr ) => {
         {
-            let function = new_naked_function($env, Some($name), $arity, &$function, false);
+            let function = new_naked_function($env, Some($name), $arity, $function, false);
             $target.define_own_property($env, $name, JsDescriptor::new_value(function, true, false, true), false).ok();
         }
     }
@@ -48,8 +48,8 @@ macro_rules! function {
 macro_rules! accessor {
     ( $target:expr , $name:expr , $get:ident , $set:ident , $prototype:expr , $env:expr ) => {
         {
-            let get_function = new_naked_function($env, Some($name), 0, &$get, $prototype, false);
-            let set_function = new_naked_function($env, Some($name), 1, &$set, $prototype, false);
+            let get_function = new_naked_function($env, Some($name), 0, $get, $prototype, false);
+            let set_function = new_naked_function($env, Some($name), 1, $set, $prototype, false);
             $target.define_own_property($env, $name, JsDescriptor::new_accessor(get_function, set_function, false, true), false).ok();
         }
     }
@@ -88,13 +88,13 @@ fn setup_global(env: &mut JsEnv) {
         global_scope.as_root(env)
     };
     
-    let mut global = env.handle(JsHandle::Global).as_value(env);
+    let mut global = env.handle(JsHandle::Global).as_value();
     
     let mut object_prototype = JsObject::new_local(&env, JsStoreType::Hash);
     env.add_handle(JsHandle::Object, object_prototype);
     
-    global.set_prototype(env, Some(object_prototype.as_value(env)));
-    global.set_class(env, Some(name::OBJECT_CLASS));
+    global.set_prototype(Some(object_prototype.as_value()));
+    global.set_class(Some(name::OBJECT_CLASS));
     
     // Constructor setup.
     
@@ -123,44 +123,44 @@ fn setup_global(env: &mut JsEnv) {
     function!(global, name::ENCODE_URI, Global_encodeURI, 1, env);
     function!(global, name::ENCODE_URI_COMPONENT, Global_encodeURIComponent, 1, env);
     
-    value!(global, name::NAN, env.new_number(f64::NAN), false, false, false, env);
-    value!(global, name::INFINITY, env.new_number(f64::INFINITY), false, false, false, env);
-    value!(global, name::UNDEFINED, env.new_undefined(), false, false, false, env);
+    value!(global, name::NAN, JsValue::new_number(f64::NAN), false, false, false, env);
+    value!(global, name::INFINITY, JsValue::new_number(f64::INFINITY), false, false, false, env);
+    value!(global, name::UNDEFINED, JsValue::new_undefined(), false, false, false, env);
 }
 
-fn setup_function(env: &mut JsEnv, mut global: Local<JsValue>, object_prototype: Local<JsObject>) -> Local<JsObject> {
+fn setup_function(env: &mut JsEnv, mut global: JsValue, object_prototype: Local<JsObject>) -> Local<JsObject> {
     let mut prototype = JsObject::new_function_with_prototype(
         env,
-        JsFunction::Native(None, 0, JsFnRef::new(&Function_baseConstructor), false),
+        JsFunction::Native(None, 0, Function_baseConstructor, false),
         object_prototype,
         false
     );
 
     env.add_handle(JsHandle::Function, prototype);
     
-    let class = new_naked_function(env, Some(name::FUNCTION_CLASS), 1, &Function_constructor, true);
+    let class = new_naked_function(env, Some(name::FUNCTION_CLASS), 1, Function_constructor, true);
     
-    let mut class_object = class.unwrap_object(env);
+    let mut class_object = class.unwrap_object();
 
-    let value = prototype.as_value(env);
+    let value = prototype.as_value();
     class_object.define_own_property(env, name::PROTOTYPE, JsDescriptor::new_value(value, false, false, false), false).ok();
     prototype.define_own_property(env, name::CONSTRUCTOR, JsDescriptor::new_value(class, true, false, true), false).ok();
     
-    class_object.set_class(env, Some(name::FUNCTION_CLASS));
+    class_object.set_class(Some(name::FUNCTION_CLASS));
     
-    property!(prototype, name::CONSTRUCTOR, class.as_value(env), true, false, true, env);
+    property!(prototype, name::CONSTRUCTOR, class.as_value(), true, false, true, env);
     
     function!(prototype, name::CALL, Function_call, 1, env);
     function!(prototype, name::APPLY, Function_apply, 2, env);
     function!(prototype, name::BIND, Function_bind, 1, env);
     function!(prototype, name::TO_STRING, Function_toString, 0, env);
     
-    property!(global, name::FUNCTION_CLASS, class.as_value(env), true, false, true, env);
+    property!(global, name::FUNCTION_CLASS, class.as_value(), true, false, true, env);
     
     prototype
 }
 
-fn setup_object<'a>(env: &mut JsEnv, mut global: Local<JsValue>, prototype: &mut Local<JsObject>) {
+fn setup_object<'a>(env: &mut JsEnv, mut global: JsValue, prototype: &mut Local<JsObject>) {
     function!(prototype, name::TO_STRING, Object_toString, 0, env);
     function!(prototype, name::TO_LOCALE_STRING, Object_toLocaleString, 0, env);
     function!(prototype, name::VALUE_OF, Object_valueOf, 0, env);
@@ -168,12 +168,12 @@ fn setup_object<'a>(env: &mut JsEnv, mut global: Local<JsValue>, prototype: &mut
     function!(prototype, name::IS_PROTOTYPE_OF, Object_isPrototypeOf, 1, env);
     function!(prototype, name::PROPERTY_IS_ENUMERABLE, Object_propertyIsEnumerable, 1, env);
     
-    let class = JsObject::new_function(env, JsFunction::Native(Some(name::OBJECT_CLASS), 1, JsFnRef::new(&Object_constructor), true), false);
-    let mut class = class.as_value(env);
+    let class = JsObject::new_function(env, JsFunction::Native(Some(name::OBJECT_CLASS), 1, Object_constructor, true), false);
+    let mut class = class.as_value();
     
     property!(global, name::OBJECT_CLASS, class, true, false, true, env);
         
-    property!(class, name::PROTOTYPE, prototype.as_value(env), false, false, false, env);
+    property!(class, name::PROTOTYPE, prototype.as_value(), false, false, false, env);
     property!(prototype, name::CONSTRUCTOR, class, true, false, true, env);
     
     function!(class, name::CREATE, Object_create, 2, env);
@@ -191,7 +191,7 @@ fn setup_object<'a>(env: &mut JsEnv, mut global: Local<JsValue>, prototype: &mut
     function!(class, name::KEYS, Object_keys, 1, env);
 }
 
-fn setup_array<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
+fn setup_array<'a>(env: &mut JsEnv, mut global: JsValue) {
     // This is a bit of a mess. Array.prototype is itself an array.
     // To get this to work, we duplicate JsEnv.new_native_function here.
     // There are two changes compared to the normal implementation.
@@ -207,7 +207,7 @@ fn setup_array<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
     
     let mut prototype = JsObject::new_local(env, JsStoreType::Array);
     
-    let length = env.new_number(0.0);
+    let length = JsValue::new_number(0.0);
     prototype.define_own_property(
         env,
         name::LENGTH,
@@ -215,13 +215,13 @@ fn setup_array<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
         false
     ).ok();
     
-    let array_prototype = prototype.as_value(env);
+    let array_prototype = prototype.as_value();
     // Set the [[Prototype]] value as usual.
-    prototype.set_prototype(env, Some(env.handle(JsHandle::Object).as_value(env)));
-    prototype.set_class(env, Some(name::ARRAY_CLASS));
+    prototype.set_prototype(Some(env.handle(JsHandle::Object).as_value()));
+    prototype.set_class(Some(name::ARRAY_CLASS));
     
     // Create the class as usual.
-    let mut class = JsObject::new_function(env, JsFunction::Native(Some(name::ARRAY_CLASS), 1, JsFnRef::new(&Array_constructor), true), false).as_value(env);
+    let mut class = JsObject::new_function(env, JsFunction::Native(Some(name::ARRAY_CLASS), 1, Array_constructor, true), false).as_value();
 
     // But set the prototype to our array intance.
     class.define_own_property(env, name::PROTOTYPE, JsDescriptor::new_value(array_prototype, false, false, false), false).ok();
@@ -258,14 +258,14 @@ fn setup_array<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
     function!(class, name::IS_ARRAY, Array_isArray, 1, env);
 }
 
-fn setup_string<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
-    let mut class = env.new_native_function(Some(name::STRING_CLASS), 1, &String_constructor);    
+fn setup_string<'a>(env: &mut JsEnv, mut global: JsValue) {
+    let mut class = env.new_native_function(Some(name::STRING_CLASS), 1, String_constructor);    
     
     function!(class, name::FROM_CHAR_CODE, String_fromCharCode, 1, env);
     
     property!(global, name::STRING_CLASS, class, true, false, true, env);
 
-    let mut prototype = class.get(env, name::PROTOTYPE).ok().unwrap().unwrap_object(env);
+    let mut prototype = class.get(env, name::PROTOTYPE).ok().unwrap().unwrap_object();
 
     env.add_handle(JsHandle::String, prototype);
     
@@ -290,8 +290,8 @@ fn setup_string<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
     function!(&mut prototype, name::TRIM, String_trim, 0, env);
 }
 
-fn setup_date<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
-    let mut class = env.new_native_function(Some(name::DATE_CLASS), 7, &Date_constructor);    
+fn setup_date<'a>(env: &mut JsEnv, mut global: JsValue) {
+    let mut class = env.new_native_function(Some(name::DATE_CLASS), 7, Date_constructor);    
     
     function!(class, name::PARSE, Date_parse, 1, env);
     function!(class, name::UTC, Date_UTC, 7, env);
@@ -299,7 +299,7 @@ fn setup_date<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
 
     property!(global, name::DATE_CLASS, class, true, false, true, env);
 
-    let mut prototype = class.get(env, name::PROTOTYPE).ok().unwrap().unwrap_object(env);
+    let mut prototype = class.get(env, name::PROTOTYPE).ok().unwrap().unwrap_object();
     
     env.add_handle(JsHandle::Date, prototype);
     
@@ -351,19 +351,19 @@ fn setup_date<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
     function!(&mut prototype, name::TO_GMT_STRING, Date_toGMTString, 0, env);
 }
 
-fn setup_number<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
-    let mut class = env.new_native_function(Some(name::NUMBER_CLASS), 1, &Number_constructor);
+fn setup_number<'a>(env: &mut JsEnv, mut global: JsValue) {
+    let mut class = env.new_native_function(Some(name::NUMBER_CLASS), 1, Number_constructor);
     
-    value!(class, name::MAX_VALUE, env.new_number(f64::MAX), false, false, false, env);
-    value!(class, name::MIN_VALUE, env.new_number(5e-324), false, false, false, env);
-    value!(class, name::NAN, env.new_number(f64::NAN), false, false, false, env);
-    value!(class, name::NEGATIVE_INFINITY, env.new_number(f64::NEG_INFINITY), false, false, false, env);
-    value!(class, name::POSITIVE_INFINITY, env.new_number(f64::INFINITY), false, false, false, env);
-    value!(class, name::EPSILON, env.new_number(2.2204460492503130808472633361816e-16), false, false, false, env);
+    value!(class, name::MAX_VALUE, JsValue::new_number(f64::MAX), false, false, false, env);
+    value!(class, name::MIN_VALUE, JsValue::new_number(5e-324), false, false, false, env);
+    value!(class, name::NAN, JsValue::new_number(f64::NAN), false, false, false, env);
+    value!(class, name::NEGATIVE_INFINITY, JsValue::new_number(f64::NEG_INFINITY), false, false, false, env);
+    value!(class, name::POSITIVE_INFINITY, JsValue::new_number(f64::INFINITY), false, false, false, env);
+    value!(class, name::EPSILON, JsValue::new_number(2.2204460492503130808472633361816e-16), false, false, false, env);
     
     property!(global, name::NUMBER_CLASS, class, true, false, true, env);
 
-    let mut prototype = class.get(env, name::PROTOTYPE).ok().unwrap().unwrap_object(env);
+    let mut prototype = class.get(env, name::PROTOTYPE).ok().unwrap().unwrap_object();
     
     env.add_handle(JsHandle::Number, prototype);
 
@@ -375,12 +375,12 @@ fn setup_number<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
     function!(&mut prototype, name::TO_PRECISION, Number_toPrecision, 1, env);
 }
 
-fn setup_boolean<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
-    let class = env.new_native_function(Some(name::BOOLEAN_CLASS), 1, &Boolean_constructor);
+fn setup_boolean<'a>(env: &mut JsEnv, mut global: JsValue) {
+    let class = env.new_native_function(Some(name::BOOLEAN_CLASS), 1, Boolean_constructor);
     
     property!(global, name::BOOLEAN_CLASS, class, true, false, true, env);
     
-    let mut prototype = class.get(env, name::PROTOTYPE).ok().unwrap().unwrap_object(env);
+    let mut prototype = class.get(env, name::PROTOTYPE).ok().unwrap().unwrap_object();
     
     env.add_handle(JsHandle::Boolean, prototype);
     
@@ -388,29 +388,29 @@ fn setup_boolean<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
     function!(&mut prototype, name::TO_STRING, Boolean_toString, 0, env);
 }
 
-fn setup_math<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
+fn setup_math<'a>(env: &mut JsEnv, mut global: JsValue) {
     let mut class = env.create_object();
     
     // 15.8.1.1 E
-    value!(class, name::E, env.new_number(f64::consts::E), false, false, false, env);
+    value!(class, name::E, JsValue::new_number(f64::consts::E), false, false, false, env);
     // 15.8.1.2 LN10
-    value!(class, name::LN10, env.new_number(f64::consts::LN_10), false, false, false, env);
+    value!(class, name::LN10, JsValue::new_number(f64::consts::LN_10), false, false, false, env);
     // 15.8.1.3 LN2
-    value!(class, name::LN2, env.new_number(f64::consts::LN_2), false, false, false, env);
+    value!(class, name::LN2, JsValue::new_number(f64::consts::LN_2), false, false, false, env);
     // 15.8.1.4 LOG2E
-    value!(class, name::LOG2E, env.new_number(f64::consts::LOG2_E), false, false, false, env);
+    value!(class, name::LOG2E, JsValue::new_number(f64::consts::LOG2_E), false, false, false, env);
     // 15.8.1.5 LOG10E
-    value!(class, name::LOG10E, env.new_number(f64::consts::LOG10_E), false, false, false, env);
+    value!(class, name::LOG10E, JsValue::new_number(f64::consts::LOG10_E), false, false, false, env);
     // 15.8.1.6 PI
-    value!(class, name::PI, env.new_number(f64::consts::PI), false, false, false, env);
+    value!(class, name::PI, JsValue::new_number(f64::consts::PI), false, false, false, env);
     // 15.8.1.7 SQRT1_2
-    value!(class, name::SQRT1_2, env.new_number(f64::consts::FRAC_1_SQRT_2), false, false, false, env);
+    value!(class, name::SQRT1_2, JsValue::new_number(f64::consts::FRAC_1_SQRT_2), false, false, false, env);
     // 15.8.1.8 SQRT2
-    value!(class, name::SQRT2, env.new_number(f64::consts::SQRT_2), false, false, false, env);
+    value!(class, name::SQRT2, JsValue::new_number(f64::consts::SQRT_2), false, false, false, env);
     
-    class.set_class(env, Some(name::MATH_CLASS));
+    class.set_class(Some(name::MATH_CLASS));
     
-    property!(global, name::MATH_CLASS, class.as_value(env), true, false, true, env);
+    property!(global, name::MATH_CLASS, class.as_value(), true, false, true, env);
     
     function!(class, name::ABS, Math_abs, 1, env);
     function!(class, name::ACOS, Math_acos, 1, env);
@@ -432,15 +432,15 @@ fn setup_math<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
     function!(class, name::TAN, Math_tan, 1, env);
 }
 
-fn setup_regexp<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
-    let class = env.new_native_function(Some(name::REGEXP_CLASS), 2, &RegExp_constructor);
+fn setup_regexp<'a>(env: &mut JsEnv, mut global: JsValue) {
+    let class = env.new_native_function(Some(name::REGEXP_CLASS), 2, RegExp_constructor);
     
-    let class_obj = class.unwrap_object(env);
+    let class_obj = class.unwrap_object();
     env.add_handle(JsHandle::RegExpClass, class_obj);
     
     property!(global, name::REGEXP_CLASS, class, true, false, true, env);
     
-    let mut prototype = class.get(env, name::PROTOTYPE).ok().unwrap().unwrap_object(env);
+    let mut prototype = class.get(env, name::PROTOTYPE).ok().unwrap().unwrap_object();
     
     env.add_handle(JsHandle::RegExp, prototype);
 
@@ -449,48 +449,48 @@ fn setup_regexp<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
     function!(&mut prototype, name::TO_STRING, RegExp_toString, 0, env);
 }
 
-fn setup_json<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
+fn setup_json<'a>(env: &mut JsEnv, mut global: JsValue) {
     let mut class = env.create_object();
     
-    class.set_class(env, Some(name::JSON_CLASS));
+    class.set_class(Some(name::JSON_CLASS));
     
-    property!(global, name::JSON_CLASS, class.as_value(env), true, false, true, env);
+    property!(global, name::JSON_CLASS, class.as_value(), true, false, true, env);
     
     function!(class, name::PARSE, JSON_parse, 2, env);
     function!(class, name::STRINGIFY, JSON_stringify, 3, env);
 }
 
-fn setup_console<'a>(env: &mut JsEnv, mut global: Local<JsValue>) {
+fn setup_console<'a>(env: &mut JsEnv, mut global: JsValue) {
     let mut class = env.create_object();
     
-    class.set_class(env, Some(name::CONSOLE_CLASS));
+    class.set_class(Some(name::CONSOLE_CLASS));
     
-    property!(global, name::CONSOLE, class.as_value(env), true, false, true, env);
+    property!(global, name::CONSOLE, class.as_value(), true, false, true, env);
     
     function!(class, name::LOG, console_log, 1, env);
 }
 
-fn setup_error<'a>(env: &mut JsEnv, global: Local<JsValue>) {
-    fn register_error(env: &mut JsEnv, mut global: Local<JsValue>, error_class: Option<Local<JsValue>>, error_prototype: Option<Local<JsValue>>, name: Name, handle: JsHandle) -> (Local<JsValue>, Local<JsValue>) {
-        let class = env.new_native_function(Some(name), 1, &Error_constructor);
+fn setup_error<'a>(env: &mut JsEnv, global: JsValue) {
+    fn register_error(env: &mut JsEnv, mut global: JsValue, error_class: Option<JsValue>, error_prototype: Option<JsValue>, name: Name, handle: JsHandle) -> (JsValue, JsValue) {
+        let class = env.new_native_function(Some(name), 1, Error_constructor);
         
-        let mut class_obj = class.unwrap_object(env);
+        let mut class_obj = class.unwrap_object();
         env.add_handle(handle, class_obj);
         
         property!(global, name, class, true, false, true, env);
         
         let prototype = class.get(env, name::PROTOTYPE).ok().unwrap();
-        let mut prototype_obj = prototype.unwrap_object(env);
+        let mut prototype_obj = prototype.unwrap_object();
         if error_prototype.is_some() {
-            prototype_obj.set_prototype(env, error_prototype);
+            prototype_obj.set_prototype(error_prototype);
         }
         if error_class.is_some() {
-            class_obj.set_prototype(env, error_class);
+            class_obj.set_prototype(error_class);
         }
         
-        let value = JsString::from_str(env, "").as_value(env);
+        let value = JsString::from_str(env, "").as_value();
         value!(&mut prototype_obj, name::MESSAGE, value, true, false, true, env);
-        let value = JsString::from_str(env, &*env.ir.interner().get(name)).as_value(env);
+        let value = JsString::from_str(env, &*env.ir.interner().get(name)).as_value();
         value!(&mut prototype_obj, name::NAME, value, true, false, true, env);
         function!(&mut prototype_obj, name::TO_STRING, Error_toString, 0, env);
         
@@ -507,6 +507,6 @@ fn setup_error<'a>(env: &mut JsEnv, global: Local<JsValue>) {
     register_error(env, global, Some(error_class), Some(error_prototype), name::NATIVE_ERROR_CLASS, JsHandle::NativeError);
 }
 
-fn new_naked_function<'a>(env: &mut JsEnv, name: Option<Name>, args: u32, function: &JsFn, can_construct: bool) -> Local<JsValue> {
-    JsObject::new_function(env, JsFunction::Native(name, args, JsFnRef::new(function), can_construct), false).as_value(env)
+fn new_naked_function<'a>(env: &mut JsEnv, name: Option<Name>, args: u32, function: JsFn, can_construct: bool) -> JsValue {
+    JsObject::new_function(env, JsFunction::Native(name, args, function, can_construct), false).as_value()
 }

--- a/src/rt/env/regexp.rs
+++ b/src/rt/env/regexp.rs
@@ -6,20 +6,20 @@ use syntax::Name;
 
 // 15.10.3 The RegExp Constructor Called as a Function
 // 15.10.4 The RegExp Constructor
-pub fn RegExp_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn RegExp_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let pattern = args.arg(env, 0);
     let flags = args.arg(env, 1);
     
     if !mode.construct() {
-        if pattern.class(env) == Some(name::REGEXP_CLASS) && flags.is_undefined() {
+        if pattern.class() == Some(name::REGEXP_CLASS) && flags.is_undefined() {
             Ok(pattern)
         } else {
             args.function(env).construct(env, vec![pattern, flags])
         }
     } else {
-        let (pattern, flags) = if pattern.class(env) == Some(name::REGEXP_CLASS) {
+        let (pattern, flags) = if pattern.class() == Some(name::REGEXP_CLASS) {
             if flags.is_undefined() {
-                let regexp = pattern.unwrap_object(env).value(env).unwrap_regexp(env);
+                let regexp = pattern.unwrap_object().value(env).unwrap_regexp();
                 
                 (regexp.pattern(env), regexp.flags(env))
             } else {
@@ -78,20 +78,20 @@ pub fn RegExp_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsRe
         ));
         
         let this_arg = args.this(env);
-        let mut this = this_arg.unwrap_object(env);
+        let mut this = this_arg.unwrap_object();
         
-        this.set_class(env, Some(name::REGEXP_CLASS));
-        this.set_value(regexp.as_value(env));
+        this.set_class(Some(name::REGEXP_CLASS));
+        this.set_value(regexp.as_value());
         
-        let value = JsDescriptor::new_value(pattern.as_value(env), false, false, false);
+        let value = JsDescriptor::new_value(pattern.as_value(), false, false, false);
         try!(this.define_own_property(env, name::SOURCE, value, true));
-        let value = JsDescriptor::new_value(env.new_bool(global), false, false, false);
+        let value = JsDescriptor::new_value(JsValue::new_bool(global), false, false, false);
         try!(this.define_own_property(env, name::GLOBAL, value, true));
-        let value = JsDescriptor::new_value(env.new_bool(ignore_case), false, false, false);
+        let value = JsDescriptor::new_value(JsValue::new_bool(ignore_case), false, false, false);
         try!(this.define_own_property(env, name::IGNORE_CASE, value, true));
-        let value = JsDescriptor::new_value(env.new_bool(multiline), false, false, false);
+        let value = JsDescriptor::new_value(JsValue::new_bool(multiline), false, false, false);
         try!(this.define_own_property(env, name::MULTILINE, value, true));
-        let value = JsDescriptor::new_value(env.new_number(0.0), true, false, false);
+        let value = JsDescriptor::new_value(JsValue::new_number(0.0), true, false, false);
         try!(this.define_own_property(env, name::LAST_INDEX, value, true));
         
         Ok(this_arg)
@@ -101,15 +101,15 @@ pub fn RegExp_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsRe
 fn unwrap_regexp(env: &mut JsEnv, args: &JsArgs) -> JsResult<Local<JsRegExp>> {
     let this = args.this(env);
     
-    if this.class(env) == Some(name::REGEXP_CLASS) {
-        Ok(this.unwrap_object(env).value(env).unwrap_regexp(env))
+    if this.class() == Some(name::REGEXP_CLASS) {
+        Ok(this.unwrap_object().value(env).unwrap_regexp())
     } else {
         Err(JsError::new_type(env, ::errors::TYPE_INVALID))
     }
 }
 
 // 15.10.6.2 RegExp.prototype.exec(string)
-pub fn RegExp_exec(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn RegExp_exec(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let regexp = try!(unwrap_regexp(env, &args));
     let mut this = args.this(env);
     
@@ -131,9 +131,9 @@ pub fn RegExp_exec(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<L
     // right. This will be fixed through #79.
     
     if last_index < 0.0 || last_index > length as f64 {
-        let value = env.new_number(0.0);
+        let value = JsValue::new_number(0.0);
         try!(this.put(env, name::LAST_INDEX, value, true));
-        return Ok(env.new_null());
+        return Ok(JsValue::new_null());
     }
     
     let last_index = last_index as usize;
@@ -148,55 +148,55 @@ pub fn RegExp_exec(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<L
         let end_index = end_index + last_index;
         
         if global {
-            let value = env.new_number(end_index as f64);
+            let value = JsValue::new_number(end_index as f64);
             try!(this.put(env, name::LAST_INDEX, value, true));
         }
         
         let mut result = env.create_array();
         
-        let value = JsDescriptor::new_simple_value(env.new_number(start_index as f64));
+        let value = JsDescriptor::new_simple_value(JsValue::new_number(start_index as f64));
         try!(result.define_own_property(env, name::INDEX, value, true));
         
-        let value = JsDescriptor::new_simple_value(input.as_value(env));
+        let value = JsDescriptor::new_simple_value(input.as_value());
         try!(result.define_own_property(env, name::INPUT, value, true));
         
         // Length is the same as capture.len() because that includes the
         // complete match as the first entry.
         let value = JsDescriptor {
-            value: Some(env.new_number(capture.len() as f64)),
+            value: Some(JsValue::new_number(capture.len() as f64)),
             ..JsDescriptor::default()
         };
         try!(result.define_own_property(env, name::LENGTH, value, true));
         
-        let matched_substr = JsString::from_str(env, &string[start_index..end_index]).as_value(env);
+        let matched_substr = JsString::from_str(env, &string[start_index..end_index]).as_value();
         let value = JsDescriptor::new_simple_value(matched_substr);
         try!(result.define_own_property(env, Name::from_index(0), value, true));
         
         for i in 1..capture.len() {
             if let Some((capture_start, capture_end)) = capture.pos(i) {
-                let capture_i = JsString::from_str(env, &string[(capture_start + last_index)..(capture_end + last_index)]).as_value(env);
+                let capture_i = JsString::from_str(env, &string[(capture_start + last_index)..(capture_end + last_index)]).as_value();
                 let value = JsDescriptor::new_simple_value(capture_i);
                 try!(result.define_own_property(env, Name::from_index(i), value, true));
             }
         }
         
-        Ok(result.as_value(env))
+        Ok(result.as_value())
     } else {
-        let value = env.new_number(0.0);
+        let value = JsValue::new_number(0.0);
         try!(this.put(env, name::LAST_INDEX, value, true));
-        Ok(env.new_null())
+        Ok(JsValue::new_null())
     }
 }
 
 // 15.10.6.3 RegExp.prototype.test(string)
-pub fn RegExp_test(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn RegExp_test(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let result = try!(RegExp_exec(env, mode, args));
     
-    Ok(env.new_bool(!result.is_null()))
+    Ok(JsValue::new_bool(!result.is_null()))
 }
 
 // 15.10.6.4 RegExp.prototype.toString()
-pub fn RegExp_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn RegExp_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let regexp = try!(unwrap_regexp(env, &args));
     
     let mut result = String::new();
@@ -215,5 +215,5 @@ pub fn RegExp_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResu
         result.push('m');
     }
     
-    Ok(JsString::from_str(env, &result).as_value(env))
+    Ok(JsString::from_str(env, &result).as_value())
 }

--- a/src/rt/env/string/mod.rs
+++ b/src/rt/env/string/mod.rs
@@ -21,11 +21,11 @@ fn get_this_string(env: &mut JsEnv, args: &JsArgs) -> JsResult<Local<JsString>> 
 // 15.5.1 The String Constructor Called as a Function
 // 15.5.2 The String Constructor
 // 15.5.5.1 length
-pub fn String_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = if args.argc > 0 {
-        try!(args.arg(env, 0).to_string(env)).as_value(env)
+        try!(args.arg(env, 0).to_string(env)).as_value()
     } else {
-        JsString::from_str(env, "").as_value(env)
+        JsString::from_str(env, "").as_value()
     };
     
     if !mode.construct() {
@@ -33,28 +33,28 @@ pub fn String_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsRe
     }
     
     let this_arg = args.this(env);
-    let mut object = this_arg.unwrap_object(env);
+    let mut object = this_arg.unwrap_object();
     
-    object.set_prototype(env, Some(env.handle(JsHandle::String).as_value(env)));
-    object.set_class(env, Some(name::STRING_CLASS));
+    object.set_prototype(Some(env.handle(JsHandle::String).as_value()));
+    object.set_class(Some(name::STRING_CLASS));
     object.set_value(arg);
     
-    let value = env.new_number(arg.unwrap_string(env).chars().len() as f64);
+    let value = JsValue::new_number(arg.unwrap_string().chars().len() as f64);
     try!(object.define_own_property(env, name::LENGTH, JsDescriptor::new_value(value, false, false, false), false));
     
     Ok(this_arg)
 }
 
 // 15.5.4.2 String.prototype.toString ( )
-pub fn String_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let this_arg = args.this(env);
     
     match this_arg.ty() {
         JsType::String => Ok(this_arg),
         JsType::Object => {
-            let object = this_arg.unwrap_object(env);
+            let object = this_arg.unwrap_object();
             
-            if object.class(env) == Some(name::STRING_CLASS) {
+            if object.class() == Some(name::STRING_CLASS) {
                 // This is safe because the constructor always sets the value.
                 Ok(object.value(env))
             } else {
@@ -66,15 +66,15 @@ pub fn String_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResu
 }
 
 // 15.5.4.3 String.prototype.valueOf ( )
-pub fn String_valueOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_valueOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let this_arg = args.this(env);
     
     match this_arg.ty() {
         JsType::String => Ok(this_arg),
         JsType::Object => {
-            let object = this_arg.unwrap_object(env);
+            let object = this_arg.unwrap_object();
             
-            if object.class(env) == Some(name::STRING_CLASS) {
+            if object.class() == Some(name::STRING_CLASS) {
                 // This is safe because the constructor always sets the value.
                 Ok(object.value(env))
             } else {
@@ -86,18 +86,18 @@ pub fn String_valueOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResul
 }
 
 // 15.5.3.2 String.fromCharCode ( [ char0 [ , char1 [ , … ] ] ] )
-pub fn String_fromCharCode(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_fromCharCode(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let mut chars = Vec::new();
     
     for i in 0..args.argc {
         chars.push(try!(args.arg(env, i).to_uint16(env)));
     }
     
-    Ok(env.new_string(JsString::from_u16(env, &chars)))
+    Ok(JsString::from_u16(env, &chars).as_value())
 }
 
 // 15.5.4.4 String.prototype.charAt (pos)
-pub fn String_charAt(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_charAt(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let this = try!(get_this_string(env, &args));
     let chars = this.chars();
     let position = try!(args.arg(env, 0).to_integer(env)) as i32;
@@ -108,11 +108,11 @@ pub fn String_charAt(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult
         char::from_u32(chars[position as usize] as u32).unwrap().to_string()
     };
     
-    Ok(JsString::from_str(env, &result).as_value(env))
+    Ok(JsString::from_str(env, &result).as_value())
 }
 
 // 15.5.4.5 String.prototype.charCodeAt (pos)
-pub fn String_charCodeAt(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_charCodeAt(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let this = try!(get_this_string(env, &args));
     let chars = this.chars();
     let position = try!(args.arg(env, 0).to_integer(env)) as i32;
@@ -123,19 +123,19 @@ pub fn String_charCodeAt(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsRe
         chars[position as usize] as f64
     };
     
-    Ok(env.new_number(result))
+    Ok(JsValue::new_number(result))
 }
 
 // 15.5.4.7 String.prototype.indexOf (searchString, position)
 // 15.5.4.8 String.prototype.lastIndexOf (searchString, position)
-fn index_of(env: &mut JsEnv, args: JsArgs, reverse: bool) -> JsResult<Local<JsValue>> {
+fn index_of(env: &mut JsEnv, args: JsArgs, reverse: bool) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args));
     let search = try!(args.arg(env, 0).to_string(env));
     
     let len = string.chars().len();
     let search_len = search.chars().len();
     if len == 0 || search_len > len {
-        return Ok(env.new_number(-1.0));
+        return Ok(JsValue::new_number(-1.0));
     }
     
     let position = args.arg(env, 1);
@@ -148,7 +148,7 @@ fn index_of(env: &mut JsEnv, args: JsArgs, reverse: bool) -> JsResult<Local<JsVa
         };
         
         if position >= len as i32 {
-            return Ok(env.new_number(-1.0));
+            return Ok(JsValue::new_number(-1.0));
         }
         
         (max(position, 0) as usize, len)
@@ -160,7 +160,7 @@ fn index_of(env: &mut JsEnv, args: JsArgs, reverse: bool) -> JsResult<Local<JsVa
         };
         
         if position < 0 {
-            return Ok(env.new_number(-1.0));
+            return Ok(JsValue::new_number(-1.0));
         }
         
         (0, position as usize)
@@ -199,21 +199,21 @@ fn index_of(env: &mut JsEnv, args: JsArgs, reverse: bool) -> JsResult<Local<JsVa
         }
     }
     
-    Ok(env.new_number(result as f64))
+    Ok(JsValue::new_number(result as f64))
 }
 
 // 15.5.4.7 String.prototype.indexOf (searchString, position)
-pub fn String_indexOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_indexOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     index_of(env, args, false)
 }
 
 // 15.5.4.8 String.prototype.lastIndexOf (searchString, position)
-pub fn String_lastIndexOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_lastIndexOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     index_of(env, args, true)
 }
 
 // 15.5.4.15 String.prototype.substring (start, end)
-pub fn String_substring(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_substring(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args));
     let len = string.chars().len() as f64;
     
@@ -233,38 +233,38 @@ pub fn String_substring(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsRes
     
     let result = JsString::from_u16(env, &string.chars()[(from as usize)..(to as usize)]);
     
-    Ok(result.as_value(env))
+    Ok(result.as_value())
 }
 
 // 15.5.4.16 String.prototype.toLowerCase ( )
-pub fn String_toLowerCase(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_toLowerCase(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args)).to_string().to_lowercase();
     let string = JsString::from_str(env, &string);
     
-    Ok(string.as_value(env))
+    Ok(string.as_value())
 }
 
 // 15.5.4.17 String.prototype.toLocaleLowerCase ( )
-pub fn String_toLocaleLowerCase(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_toLocaleLowerCase(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     String_toLowerCase(env, mode, args)
 }
 
 // 15.5.4.18 String.prototype.toUpperCase ( )
-pub fn String_toUpperCase(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_toUpperCase(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args)).to_string().to_uppercase();
     let string = JsString::from_str(env, &string);
     
-    Ok(string.as_value(env))
+    Ok(string.as_value())
 }
 
 // 15.5.4.19 String.prototype.toLocaleUpperCase ( )
-pub fn String_toLocaleUpperCase(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_toLocaleUpperCase(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     String_toUpperCase(env, mode, args)
 }
 
 
 // 15.5.4.6 String.prototype.concat ( [ string1 [ , string2 [ , … ] ] ] )
-pub fn String_concat(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_concat(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args));
     
     let mut strings = Vec::with_capacity(args.argc + 1);
@@ -275,12 +275,12 @@ pub fn String_concat(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult
         strings.push(arg);
     }
     
-    Ok(JsString::concat(env, &strings).as_value(env))
+    Ok(JsString::concat(env, &strings).as_value())
 }
 
 
 // 15.5.4.9 String.prototype.localeCompare (that)
-pub fn String_localeCompare(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_localeCompare(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args));
     let that = try!(args.arg(env, 0).to_string(env));
     
@@ -295,10 +295,10 @@ pub fn String_localeCompare(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> J
         let that_c = that[i];
         
         if string_c < that_c {
-            return Ok(env.new_number(-1.0));
+            return Ok(JsValue::new_number(-1.0));
         }
         if string_c > that_c {
-            return Ok(env.new_number(1.0));
+            return Ok(JsValue::new_number(1.0));
         }
     }
     
@@ -310,28 +310,28 @@ pub fn String_localeCompare(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> J
         0.0
     };
     
-    Ok(env.new_number(result))
+    Ok(JsValue::new_number(result))
 }
 
 // 15.5.4.10 String.prototype.match (regexp)
-pub fn String_match(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
-    let string = try!(get_this_string(env, &args)).as_value(env);
+pub fn String_match(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
+    let string = try!(get_this_string(env, &args)).as_value();
     
     let regex = args.arg(env, 0);
-    let mut rx = if regex.class(env) == Some(name::REGEXP_CLASS) {
+    let mut rx = if regex.class() == Some(name::REGEXP_CLASS) {
         regex
     } else {
         try!(env.handle(JsHandle::RegExpClass).construct(env, vec![regex]))
     };
     
-    let global = rx.unwrap_object(env).value(env).unwrap_regexp(env).global();
+    let global = rx.unwrap_object().value(env).unwrap_regexp().global();
     
     let exec = try!(rx.get(env, name::EXEC));
     
     let result = if !global {
         try!(exec.call(env, rx, vec![string], false))
     } else {
-        let value = env.new_number(0.0);
+        let value = JsValue::new_number(0.0);
         try!(rx.put(env, name::LAST_INDEX, value, true));
         
         let mut array = env.create_array();
@@ -347,7 +347,7 @@ pub fn String_match(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
             
             let this_index = try!(try!(rx.get(env, name::LAST_INDEX)).to_integer(env)) as isize;
             if this_index == previous_last_index {
-                let value = env.new_number((this_index + 1) as f64);
+                let value = JsValue::new_number((this_index + 1) as f64);
                 try!(rx.put(env, name::LAST_INDEX, value, true));
                 previous_last_index = this_index + 1;
             } else {
@@ -366,9 +366,9 @@ pub fn String_match(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
         }
         
         if n == 0 {
-            env.new_null()
+            JsValue::new_null()
         } else {
-            array.as_value(env)
+            array.as_value()
         }
     };
     
@@ -376,22 +376,22 @@ pub fn String_match(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
 }
 
 // 15.5.4.11 String.prototype.replace (searchValue, replaceValue)
-pub fn String_replace(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_replace(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     replacer::Replacer::replace(env, args, mode.strict())
 }
 
 // 15.5.4.12 String.prototype.search (regexp)
-pub fn String_search(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_search(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args));
     
     let regex = args.arg(env, 0);
-    let rx = if regex.class(env) == Some(name::REGEXP_CLASS) {
+    let rx = if regex.class() == Some(name::REGEXP_CLASS) {
         regex
     } else {
         try!(env.handle(JsHandle::RegExpClass).construct(env, vec![regex]))
     };
     
-    let regexp = rx.unwrap_object(env).value(env).unwrap_regexp(env);
+    let regexp = rx.unwrap_object().value(env).unwrap_regexp();
     
     let string = string.to_string();
     
@@ -401,11 +401,11 @@ pub fn String_search(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult
         -1.0
     };
     
-    Ok(env.new_number(result))
+    Ok(JsValue::new_number(result))
 }
 
 // 15.5.4.13 String.prototype.slice (start, end)
-pub fn String_slice(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_slice(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args));
     
     let len = string.chars().len() as f64;
@@ -432,26 +432,26 @@ pub fn String_slice(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
     };
     
     if start >= len {
-        Ok(JsString::from_str(env, "").as_value(env))
+        Ok(JsString::from_str(env, "").as_value())
     } else {
         let span = (end - start).max(0.0);
         
-        Ok(JsString::from_u16(env, &string.chars()[(start as usize)..((start + span) as usize)]).as_value(env))
+        Ok(JsString::from_u16(env, &string.chars()[(start as usize)..((start + span) as usize)]).as_value())
     }
 }
 
 // 15.5.4.14 String.prototype.split (separator, limit)
-pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     struct MatchResult {
         index: usize,
         end_index: usize,
-        captures: Vec<Local<JsValue>>
+        captures: Vec<JsValue>
     }
     
-    fn split_match(env: &mut JsEnv, string: Local<JsValue>, offset: usize, separator: Local<JsValue>) -> JsResult<Option<MatchResult>> {
-        if separator.class(env) == Some(name::REGEXP_CLASS) {
+    fn split_match(env: &mut JsEnv, string: JsValue, offset: usize, separator: JsValue) -> JsResult<Option<MatchResult>> {
+        if separator.class() == Some(name::REGEXP_CLASS) {
             let exec = try!(separator.get(env, name::EXEC));
-            let string = JsString::from_u16(env, &string.unwrap_string(env).chars()[offset..]).as_value(env);
+            let string = JsString::from_u16(env, &string.unwrap_string().chars()[offset..]).as_value();
             let matches = try!(exec.call(env, separator, vec![string], false));
             
             if matches.is_null() {
@@ -475,11 +475,11 @@ pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
                 }))
             }
         } else {
-            let separator = separator.unwrap_string(env);
+            let separator = separator.unwrap_string();
             let separator = separator.chars();
             let length = separator.len();
             
-            let string = string.unwrap_string(env);
+            let string = string.unwrap_string();
             let string = string.chars();
             let string_length = string.len();
             
@@ -502,7 +502,7 @@ pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
     }
     
     let string = try!(get_this_string(env, &args));
-    let string_value = string.as_value(env);
+    let string_value = string.as_value();
     
     let mut array = env.create_array();
     let mut array_length = 0;
@@ -520,17 +520,17 @@ pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
     
     let separator = {
         let separator = args.arg(env, 0);
-        if separator.class(env) == Some(name::REGEXP_CLASS) {
+        if separator.class() == Some(name::REGEXP_CLASS) {
             separator
         } else if separator.is_undefined() {
             separator
         } else {
-            try!(separator.to_string(env)).as_value(env)
+            try!(separator.to_string(env)).as_value()
         }
     };
     
     if limit == 0 {
-        Ok(array.as_value(env))
+        Ok(array.as_value())
     } else {
         if separator.is_undefined() {
             try!(array.define_own_property(
@@ -563,7 +563,7 @@ pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
                         } else {
                             offset = match_result.index;
                             
-                            let part = JsString::from_u16(env, &string.chars()[last_offset..offset]).as_value(env);
+                            let part = JsString::from_u16(env, &string.chars()[last_offset..offset]).as_value();
                             
                             try!(array.define_own_property(
                                 env,
@@ -574,7 +574,7 @@ pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
                             
                             array_length += 1;
                             if array_length == limit as usize {
-                                return Ok(array.as_value(env));
+                                return Ok(array.as_value());
                             }
                             
                             last_offset = match_result.end_index;
@@ -589,7 +589,7 @@ pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
                                 
                                 array_length += 1;
                                 if array_length == limit as usize {
-                                    return Ok(array.as_value(env))
+                                    return Ok(array.as_value())
                                 }
                             }
                             
@@ -599,7 +599,7 @@ pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
                 }
             }
             
-            let remaining = JsString::from_u16(env, &string.chars()[last_offset..string_length]).as_value(env);
+            let remaining = JsString::from_u16(env, &string.chars()[last_offset..string_length]).as_value();
             try!(array.define_own_property(
                 env,
                 Name::from_index(array_length),
@@ -608,12 +608,12 @@ pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
             ));
         }
         
-        Ok(array.as_value(env))
+        Ok(array.as_value())
     }
 }
 
 // 15.5.4.20 String.prototype.trim ( )
-pub fn String_trim(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_trim(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args));
     
     let chars = string.chars();
@@ -647,8 +647,8 @@ pub fn String_trim(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<L
             end -= 1;
         }
         
-        Ok(JsString::from_u16(env, &chars[start..end]).as_value(env))
+        Ok(JsString::from_u16(env, &chars[start..end]).as_value())
     } else {
-        Ok(JsString::from_str(env, "").as_value(env))
+        Ok(JsString::from_str(env, "").as_value())
     }
 }

--- a/src/rt/iterator.rs
+++ b/src/rt/iterator.rs
@@ -15,15 +15,15 @@ pub struct JsIterator {
 }
 
 impl JsIterator {
-    pub fn new_local(env: &JsEnv, target: Local<JsValue>) -> Local<JsIterator> {
+    pub fn new_local(env: &JsEnv, target: JsValue) -> Local<JsIterator> {
         let mut result = env.heap.alloc_local::<JsIterator>(GC_ITERATOR);
         
         let target = match target.ty() {
-            JsType::Object => target.unwrap_object(env).as_ptr(),
+            JsType::Object => target.unwrap_object().as_ptr(),
             JsType::Null | JsType::Undefined => Ptr::null(),
             _ => {
                 if let Some(prototype) = target.prototype(env) {
-                    prototype.unwrap_object(env).as_ptr()
+                    prototype.unwrap_object().as_ptr()
                 } else {
                     Ptr::null()
                 }
@@ -45,8 +45,8 @@ impl JsIterator {
 }
 
 impl Local<JsIterator> {
-    pub fn as_value(&self, env: &JsEnv) -> Local<JsValue> {
-        env.new_iterator(*self)
+    pub fn as_value(&self) -> JsValue {
+        JsValue::new_iterator(*self)
     }
     
     pub fn next(&mut self, env: &JsEnv) -> bool {
@@ -72,7 +72,7 @@ impl Local<JsIterator> {
                 }
                 JsStoreKey::End => {
                     if let Some(prototype) = target.prototype(env) {
-                        target = prototype.unwrap_object(env);
+                        target = prototype.unwrap_object();
                         
                         self.target = target.as_ptr();
                         self.offset = 0;

--- a/src/rt/null.rs
+++ b/src/rt/null.rs
@@ -1,20 +1,19 @@
 use rt::{JsItem, JsEnv, JsValue, JsDescriptor};
-use gc::Local;
 use ::{JsResult, JsError};
 use syntax::Name;
 
 pub struct JsNull;
 
 impl JsItem for JsNull {
-    fn as_value(&self, env: &JsEnv) -> Local<JsValue> {
-        env.new_null()
+    fn as_value(&self) -> JsValue {
+        JsValue::new_null()
     }
     
     fn get_property(&self, _: &JsEnv, _: Name) -> Option<JsDescriptor> {
         None
     }
     
-    fn get(&self, env: &mut JsEnv, _: Name) -> JsResult<Local<JsValue>> {
+    fn get(&self, env: &mut JsEnv, _: Name) -> JsResult<JsValue> {
         Err(JsError::new_type(env, ::errors::TYPE_NULL))
     }
     
@@ -22,7 +21,7 @@ impl JsItem for JsNull {
         panic!("not supported");
     }
     
-    fn put(&mut self, env: &mut JsEnv, _: Name, _: Local<JsValue>, _: bool) -> JsResult<()> {
+    fn put(&mut self, env: &mut JsEnv, _: Name, _: JsValue, _: bool) -> JsResult<()> {
         Err(JsError::new_type(env, ::errors::TYPE_NULL))
     }
     

--- a/src/rt/number.rs
+++ b/src/rt/number.rs
@@ -1,5 +1,4 @@
 use rt::{JsItem, JsEnv, JsValue, JsHandle};
-use gc::Local;
 
 pub struct JsNumber {
     value: f64
@@ -14,15 +13,15 @@ impl JsNumber {
 }
 
 impl JsItem for JsNumber {
-    fn as_value(&self, env: &JsEnv) -> Local<JsValue> {
-        env.new_number(self.value)
+    fn as_value(&self) -> JsValue {
+        JsValue::new_number(self.value)
     }
     
-    fn has_prototype(&self, _: &JsEnv) -> bool {
+    fn has_prototype(&self) -> bool {
         true
     }
     
-    fn prototype(&self, env: &JsEnv) -> Option<Local<JsValue>> {
-        Some(env.handle(JsHandle::Number).as_value(env))
+    fn prototype(&self, env: &JsEnv) -> Option<JsValue> {
+        Some(env.handle(JsHandle::Number).as_value())
     }
 }

--- a/src/rt/object/array_store.rs
+++ b/src/rt/object/array_store.rs
@@ -4,10 +4,11 @@ use rt::object::{Store, StoreKey, Entry};
 use rt::object::hash_store::HashStore;
 use syntax::Name;
 use gc::{Local, GcWalker, GcAllocator, AsPtr, Ptr, ptr_t};
-use std::mem::{transmute, zeroed};
+use std::mem::{transmute, zeroed, size_of};
 use rt::object::sparse_array::SparseArray;
 
 // Modifications to this struct must be synchronized with the GC walker.
+#[repr(C)]
 pub struct ArrayStore {
     array: Ptr<SparseArray>,
     props: Ptr<HashStore>
@@ -126,4 +127,6 @@ pub unsafe fn validate_walker_for_array_store(walker: &GcWalker) {
     object.props = Ptr::from_ptr(transmute(1usize));
     validate_walker_field(walker, GC_ARRAY_STORE, ptr, true);
     object.props = Ptr::null();
+    
+    assert_eq!(size_of::<ArrayStore>(), 16);
 }

--- a/src/rt/regexp.rs
+++ b/src/rt/regexp.rs
@@ -6,9 +6,10 @@ use gc::*;
 use self::regex::Regex;
 use util::manualbox::ManualBox;
 use ::{JsResult, JsError};
-use std::mem::{transmute, zeroed};
+use std::mem::{transmute, zeroed, size_of};
 
 // Modifications to this struct must be synchronized with the GC walker.
+#[repr(C)]
 pub struct JsRegExp {
     pattern: Ptr<JsString>,
     flags: Ptr<JsString>,
@@ -166,8 +167,8 @@ impl JsRegExp {
 }
 
 impl Local<JsRegExp> {
-    pub fn as_value(&self, env: &JsEnv) -> Local<JsValue> {
-        env.new_regexp(*self)
+    pub fn as_value(&self) -> JsValue {
+        JsValue::new_regexp(*self)
     }
     
     pub fn regex<'a>(&'a self) -> &'a Regex {
@@ -222,4 +223,6 @@ pub unsafe fn validate_walker(walker: &GcWalker) {
     object.multiline = true;
     validate_walker_field(walker, GC_REGEXP, ptr, false);
     object.multiline = false;
+    
+    assert_eq!(size_of::<JsRegExp>(), 32);
 }

--- a/src/rt/scope.rs
+++ b/src/rt/scope.rs
@@ -1,9 +1,9 @@
-use rt::{JsEnv, JsValue, JsObject, JsItem, GC_SCOPE, GC_VALUE};
+use rt::{JsEnv, JsRawValue, JsValue, JsObject, JsItem, GC_SCOPE, GC_VALUE};
 use gc::*;
 
 // Modifications to this struct must be synchronized with the GC walker.
 pub struct JsScope {
-    items: Array<JsValue>
+    items: Array<JsRawValue>
 }
 
 impl JsScope {
@@ -15,7 +15,7 @@ impl JsScope {
         }
         
         if let Some(parent) = parent {
-            result.raw_set(0, parent.as_value(env));
+            result.raw_set(0, parent.as_value());
         }
         
         result
@@ -31,30 +31,30 @@ impl JsScope {
         }
         
         if let Some(parent) = parent {
-            result.raw_set(0, parent.as_value(env));
+            result.raw_set(0, parent.as_value());
         }
-        result.raw_set(1, scope_object.as_value(env));
+        result.raw_set(1, scope_object.as_value());
         
         result
     }
 }
 
 impl Local<JsScope> {
-    pub fn as_value(&self, env: &JsEnv) -> Local<JsValue> {
-        env.new_scope(*self)
+    pub fn as_value(&self) -> JsValue {
+        JsValue::new_scope(*self)
     }
     
     pub fn parent(&self, env: &JsEnv) -> Option<Local<JsScope>> {
         let parent = self.raw_get(env, 0);
         
-        if parent.is_undefined() { None } else { Some(parent.unwrap_scope(env)) }
+        if parent.is_undefined() { None } else { Some(parent.unwrap_scope()) }
     }
     
     pub fn scope_object(&self, env: &JsEnv) -> Local<JsObject> {
-        self.raw_get(env, 1).unwrap_object(env)
+        self.raw_get(env, 1).unwrap_object()
     }
     
-    pub fn arguments(&self, env: &JsEnv) -> Option<Local<JsValue>> {
+    pub fn arguments(&self, env: &JsEnv) -> Option<JsValue> {
         if self.items.len() == 2 {
             None
         } else {
@@ -62,7 +62,7 @@ impl Local<JsScope> {
         }
     }
     
-    pub fn set_arguments(&mut self, arguments: Local<JsValue>) {
+    pub fn set_arguments(&mut self, arguments: JsValue) {
         if self.items.len() == 2 {
             panic!("scope does not have a slot to store arguments");
         }
@@ -74,23 +74,19 @@ impl Local<JsScope> {
         self.items.len() - 1
     }
     
-    pub fn get(&self, env: &JsEnv, index: usize) -> Local<JsValue> {
+    pub fn get(&self, env: &JsEnv, index: usize) -> JsValue {
         self.raw_get(env, index + 1)
     }
     
-    pub fn set(&mut self, index: usize, value: Local<JsValue>) {
+    pub fn set(&mut self, index: usize, value: JsValue) {
         self.raw_set(index + 1, value)
     }
     
-    fn raw_get(&self, env: &JsEnv, index: usize) -> Local<JsValue> {
-        let mut local = env.new_value();
-        
-        *local = self.items[index];
-        
-        local
+    fn raw_get(&self, env: &JsEnv, index: usize) -> JsValue {
+        self.items[index].as_value(env)
     }
     
-    fn raw_set(&mut self, index: usize, value: Local<JsValue>) {
-        self.items[index] = *value;
+    fn raw_set(&mut self, index: usize, value: JsValue) {
+        self.items[index] = value.as_raw();
     }
 }

--- a/src/rt/string.rs
+++ b/src/rt/string.rs
@@ -111,23 +111,23 @@ impl JsString {
 }
 
 impl JsItem for Local<JsString> {
-    fn as_value(&self, env: &JsEnv) -> Local<JsValue> {
-        env.new_string(*self)
+    fn as_value(&self) -> JsValue {
+        JsValue::new_string(*self)
     }
     
-    fn has_prototype(&self, _: &JsEnv) -> bool {
+    fn has_prototype(&self) -> bool {
         true
     }
     
-    fn prototype(&self, env: &JsEnv) -> Option<Local<JsValue>> {
-        Some(env.handle(JsHandle::String).as_value(env))
+    fn prototype(&self, env: &JsEnv) -> Option<JsValue> {
+        Some(env.handle(JsHandle::String).as_value())
     }
     
     // 15.5.5.2 [[GetOwnProperty]] ( P )
     // 15.5.5.1 length
     fn get_own_property(&self, env: &JsEnv, property: Name) -> Option<JsDescriptor> {
         if property == name::LENGTH {
-            let value = env.new_number(self.chars.len() as f64);
+            let value = JsValue::new_number(self.chars.len() as f64);
             return Some(JsDescriptor::new_value(value, false, false, false));
         }
         
@@ -137,7 +137,7 @@ impl JsItem for Local<JsString> {
                 let char = chars[index];
                 let mut string = JsString::new_local(env, 1);
                 string.chars[0] = char;
-                return Some(JsDescriptor::new_value(string.as_value(env), false, true, false));
+                return Some(JsDescriptor::new_value(string.as_value(), false, true, false));
             }
         }
         

--- a/src/rt/undefined.rs
+++ b/src/rt/undefined.rs
@@ -1,20 +1,19 @@
 use rt::{JsItem, JsEnv, JsValue, JsDescriptor};
-use gc::Local;
 use ::{JsResult, JsError};
 use syntax::Name;
 
 pub struct JsUndefined;
 
 impl JsItem for JsUndefined {
-    fn as_value(&self, env: &JsEnv) -> Local<JsValue> {
-        env.new_undefined()
+    fn as_value(&self) -> JsValue {
+        JsValue::new_undefined()
     }
     
     fn get_property(&self, _: &JsEnv, _: Name) -> Option<JsDescriptor> {
         None
     }
     
-    fn get(&self, env: &mut JsEnv, _: Name) -> JsResult<Local<JsValue>> {
+    fn get(&self, env: &mut JsEnv, _: Name) -> JsResult<JsValue> {
         Err(JsError::new_type(env, ::errors::TYPE_UNDEFINED))
     }
     
@@ -22,7 +21,7 @@ impl JsItem for JsUndefined {
         panic!("not supported");
     }
     
-    fn put(&mut self, env: &mut JsEnv, _: Name, _: Local<JsValue>, _: bool) -> JsResult<()> {
+    fn put(&mut self, env: &mut JsEnv, _: Name, _: JsValue, _: bool) -> JsResult<()> {
         Err(JsError::new_type(env, ::errors::TYPE_UNDEFINED))
     }
     

--- a/src/rt/value.rs
+++ b/src/rt/value.rs
@@ -35,21 +35,162 @@ const DOUBLE_EXPONENT_BITS    : u64 = 0x7ff0000000000000u64;
 #[allow(dead_code)]
 const DOUBLE_SIGNIFICANT_BITS : u64 = 0x000fffffffffffffu64;
 
-#[derive(Copy, Clone, PartialEq)]
-pub struct JsValue {
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct JsRawValue {
     ty: JsType,
-    value: JsRawValue
+    value: Data
 }
 
-impl PartialEq for Local<JsValue> {
-    fn eq(&self, other: &Local<JsValue>) -> bool {
-        **self == **other
+impl fmt::Debug for JsRawValue {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(write!(fmt, "JsRawValue {{ ty: {:?}, value: ", self.ty));
+        match self.ty {
+            JsType::Undefined => try!(write!(fmt, "undefined")),
+            JsType::Null => try!(write!(fmt, "null")),
+            JsType::Number => try!(write!(fmt, "{}", self.unwrap_number())),
+            JsType::Boolean => try!(write!(fmt, "{}", self.unwrap_bool())),
+            JsType::String => try!(write!(fmt, "string")),
+            JsType::Object => try!(write!(fmt, "object")),
+            _ => panic!("unexpected type")
+        }
+        try!(write!(fmt, " }}"));
+        
+        Ok(())
+    }
+}
+
+impl JsRawValue {
+    pub fn new_undefined() -> JsRawValue {
+        JsRawValue {
+            ty: JsType::Undefined,
+            value: Data::new()
+        }
+    }
+    
+    pub fn new_null() -> JsRawValue {
+        JsRawValue {
+            ty: JsType::Null,
+            value: Data::new()
+        }
+    }
+    
+    pub fn new_number(value: f64) -> JsRawValue {
+        JsRawValue {
+            ty: JsType::Number,
+            value: Data::new_number(value)
+        }
+    }
+    
+    pub fn new_bool(value: bool) -> JsRawValue {
+        JsRawValue {
+            ty: JsType::Boolean,
+            value: Data::new_bool(value)
+        }
+    }
+    
+    pub fn ty(&self) -> JsType {
+        self.ty
+    }
+    
+    fn unwrap_number(&self) -> f64 {
+        assert_eq!(self.ty, JsType::Number);
+        
+        self.value.get_number()
+    }
+    
+    fn unwrap_bool(&self) -> bool {
+        assert_eq!(self.ty, JsType::Boolean);
+        
+        self.value.get_bool()
+    }
+    
+    fn get_ptr<T>(&self) -> Ptr<T> {
+        self.value.get_ptr()
+    }
+    
+    pub fn as_value<T: GcAllocator>(&self, allocator: &T) -> JsValue {
+        let value = if self.ty.is_ptr() {
+            LocalData::new_local(allocator.alloc_local_from_ptr::<()>(self.get_ptr()))
+        } else {
+            LocalData {
+                data: self.value.data
+            }
+        };
+        
+        JsValue {
+            ty: self.ty,
+            value: value
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+struct Data {
+    data: u64
+}
+
+impl Data {
+    fn new() -> Data {
+        Data {
+            data: 0
+        }
+    }
+    
+    fn new_number(value: f64) -> Data {
+        Data {
+            data: unsafe { transmute(value) }
+        }
+    }
+    
+    fn new_bool(value: bool) -> Data {
+        Data {
+            data: unsafe { transmute::<_, u8>(value) as u64 }
+        }
+    }
+    
+    fn new_ptr<T, U: AsPtr<T>>(value: U) -> Data {
+        Data {
+            data: value.as_ptr().ptr() as u64
+        }
+    }
+    
+    fn get_number(&self) -> f64 {
+        unsafe { transmute(self.data) }
+    }
+    
+    fn get_bool(&self) -> bool {
+        unsafe { transmute(self.data as u8) }
+    }
+    
+    fn get_ptr<T>(&self) -> Ptr<T> {
+        Ptr::from_ptr(self.data as ptr_t)
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct JsValue {
+    ty: JsType,
+    value: LocalData
+}
+
+impl PartialEq for JsValue {
+    fn eq(&self, other: &JsValue) -> bool {
+        if self.ty != other.ty {
+            false
+        } else {
+            if self.ty.is_ptr() {
+                self.value.get_local::<()>().as_ptr() == other.value.get_local::<()>().as_ptr()
+            } else {
+                self.value.data == other.value.data
+            }
+        }
     }
 }
 
 impl fmt::Debug for JsValue {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(fmt, "JsValue {{ ty: {:?}, value: ", self.ty));
+        try!(write!(fmt, "JsRawValue {{ ty: {:?}, value: ", self.ty));
         match self.ty {
             JsType::Undefined => try!(write!(fmt, "undefined")),
             JsType::Null => try!(write!(fmt, "null")),
@@ -69,28 +210,63 @@ impl JsValue {
     pub fn new_undefined() -> JsValue {
         JsValue {
             ty: JsType::Undefined,
-            value: JsRawValue::new()
+            value: LocalData::new()
         }
     }
     
     pub fn new_null() -> JsValue {
         JsValue {
             ty: JsType::Null,
-            value: JsRawValue::new()
+            value: LocalData::new()
         }
     }
     
     pub fn new_number(value: f64) -> JsValue {
         JsValue {
             ty: JsType::Number,
-            value: JsRawValue::new_number(value)
+            value: LocalData::new_number(value)
         }
     }
     
     pub fn new_bool(value: bool) -> JsValue {
         JsValue {
             ty: JsType::Boolean,
-            value: JsRawValue::new_bool(value)
+            value: LocalData::new_bool(value)
+        }
+    }
+    
+    pub fn new_string(value: Local<JsString>) -> JsValue {
+        JsValue {
+            ty: JsType::String,
+            value: LocalData::new_local(value)
+        }
+    }
+    
+    pub fn new_object(value: Local<JsObject>) -> JsValue {
+        JsValue {
+            ty: JsType::Object,
+            value: LocalData::new_local(value)
+        }
+    }
+    
+    pub fn new_iterator(value: Local<JsIterator>) -> JsValue {
+        JsValue {
+            ty: JsType::Iterator,
+            value: LocalData::new_local(value)
+        }
+    }
+    
+    pub fn new_scope(value: Local<JsScope>) -> JsValue {
+        JsValue {
+            ty: JsType::Scope,
+            value: LocalData::new_local(value)
+        }
+    }
+    
+    pub fn new_regexp(value: Local<JsRegExp>) -> JsValue {
+        JsValue {
+            ty: JsType::RegExp,
+            value: LocalData::new_local(value)
         }
     }
     
@@ -123,156 +299,53 @@ impl JsValue {
         self.value.get_bool()
     }
     
-    pub fn get_ptr<T>(&self) -> Ptr<T> {
-        self.value.get_ptr()
-    }
-}
-
-macro_rules! delegate {
-    ( $target:expr, $env:expr, $method:ident ( $( $arg:expr ),* ) ) => {
-        match $target.ty() {
-            JsType::Undefined => JsUndefined.$method( $( $arg ),* ),
-            JsType::Null => JsNull.$method( $( $arg ),* ),
-            JsType::Number => JsNumber::new($target.unwrap_number()).$method( $( $arg ),* ),
-            JsType::Boolean => JsBoolean::new($target.unwrap_bool()).$method( $( $arg ),* ),
-            JsType::Object => $target.unwrap_object($env).$method( $( $arg ),* ),
-            JsType::String => $target.unwrap_string($env).$method( $( $arg ),* ),
-            _ => panic!("unexpected type")
-        }
-    }
-}
-
-impl JsItem for Local<JsValue> {
-    fn as_value(&self, _: &JsEnv) -> Local<JsValue> {
-        *self
-    }
-    
-    fn get_own_property(&self, env: &JsEnv, property: Name) -> Option<JsDescriptor> {
-        delegate!(self, env, get_own_property(env, property))
-    }
-    
-    fn get_property(&self, env: &JsEnv, property: Name) -> Option<JsDescriptor> {
-        delegate!(self, env, get_property(env, property))
-    }
-    
-    fn get(&self, env: &mut JsEnv, property: Name) -> JsResult<Local<JsValue>> {
-        delegate!(self, env, get(env, property))
-    }
-    
-    fn can_put(&self, env: &JsEnv, property: Name) -> bool {
-        delegate!(self, env, can_put(env, property))
-    }
-    
-    fn put(&mut self, env: &mut JsEnv, property: Name, value: Local<JsValue>, throw: bool) -> JsResult<()> {
-        delegate!(self, env, put(env, property, value, throw))
-    }
-    
-    fn has_property(&self, env: &JsEnv, property: Name) -> bool {
-        delegate!(self, env, has_property(env, property))
-    }
-    
-    fn delete(&mut self, env: &mut JsEnv, property: Name, throw: bool) -> JsResult<bool> {
-        delegate!(self, env, delete(env, property, throw))
-    }
-    
-    fn default_value(&self, env: &mut JsEnv, hint: JsPreferredType) -> JsResult<Local<JsValue>> {
-        delegate!(self, env, default_value(env, hint))
-    }
-    
-    fn define_own_property(&mut self, env: &mut JsEnv, property: Name, descriptor: JsDescriptor, throw: bool) -> JsResult<bool> {
-        delegate!(self, env, define_own_property(env, property, descriptor, throw))
-    }
-    
-    fn is_callable(&self, env: &JsEnv) -> bool  {
-        delegate!(self, env, is_callable(env))
-    }
-    
-    fn call(&self, env: &mut JsEnv, this: Local<JsValue>, args: Vec<Local<JsValue>>, strict: bool) -> JsResult<Local<JsValue>>  {
-        delegate!(self, env, call(env, this, args, strict))
-    }
-    
-    fn can_construct(&self, env: &JsEnv) -> bool  {
-        delegate!(self, env, can_construct(env))
-    }
-    
-    fn construct(&self, env: &mut JsEnv, args: Vec<Local<JsValue>>) -> JsResult<Local<JsValue>>  {
-        delegate!(self, env, construct(env, args))
-    }
-    
-    fn has_prototype(&self, env: &JsEnv) -> bool  {
-        delegate!(self, env, has_prototype(env))
-    }
-    
-    fn prototype(&self, env: &JsEnv) -> Option<Local<JsValue>>  {
-        delegate!(self, env, prototype(env))
-    }
-    
-    fn set_prototype(&mut self, env: &JsEnv, prototype: Option<Local<JsValue>>)  {
-        delegate!(self, env, set_prototype(env, prototype))
-    }
-    
-    fn has_class(&self, env: &JsEnv) -> bool  {
-        delegate!(self, env, has_class(env))
-    }
-    
-    fn class(&self, env: &JsEnv) -> Option<Name>  {
-        delegate!(self, env, class(env))
-    }
-    
-    fn set_class(&mut self, env: &JsEnv, class: Option<Name>)  {
-        delegate!(self, env, set_class(env, class))
-    }
-    
-    fn is_extensible(&self, env: &JsEnv) -> bool  {
-        delegate!(self, env, is_extensible(env))
-    }
-    
-    fn has_instance(&self, env: &mut JsEnv, object: Local<JsValue>) -> JsResult<bool>  {
-        delegate!(self, env, has_instance(env, object))
-    }
-    
-    fn scope(&self, env: &JsEnv) -> Option<Local<JsScope>>  {
-        delegate!(self, env, scope(env))
-    }
-    
-    fn set_scope(&mut self, env: &JsEnv, scope: Option<Local<JsScope>>) {
-        delegate!(self, env, set_scope(env, scope))
-    }
-}
-
-impl Local<JsValue> {
-    pub fn unwrap_string<T: GcAllocator>(&self, allocator: &T) -> Local<JsString> {
+    pub fn unwrap_string(&self) -> Local<JsString> {
         assert_eq!(self.ty, JsType::String);
         
-        self.value.get_ptr::<JsString>().as_local(allocator)
+        self.value.get_local::<JsString>()
     }
     
-    pub fn unwrap_object<T: GcAllocator>(&self, allocator: &T) -> Local<JsObject> {
+    pub fn unwrap_object(&self) -> Local<JsObject> {
         assert_eq!(self.ty, JsType::Object);
         
-        self.value.get_ptr::<JsObject>().as_local(allocator)
+        self.value.get_local::<JsObject>()
     }
     
-    pub fn unwrap_iterator<T: GcAllocator>(&self, allocator: &T) -> Local<JsIterator> {
+    pub fn unwrap_iterator(&self) -> Local<JsIterator> {
         assert_eq!(self.ty, JsType::Iterator);
         
-        self.value.get_ptr::<JsIterator>().as_local(allocator)
+        self.value.get_local::<JsIterator>()
     }
     
-    pub fn unwrap_scope<T: GcAllocator>(&self, allocator: &T) -> Local<JsScope> {
+    pub fn unwrap_scope(&self) -> Local<JsScope> {
         assert_eq!(self.ty, JsType::Scope);
         
-        self.value.get_ptr::<JsScope>().as_local(allocator)
+        self.value.get_local::<JsScope>()
     }
     
-    pub fn unwrap_regexp<T: GcAllocator>(&self, allocator: &T) -> Local<JsRegExp> {
+    pub fn unwrap_regexp(&self) -> Local<JsRegExp> {
         assert_eq!(self.ty, JsType::RegExp);
         
-        self.value.get_ptr::<JsRegExp>().as_local(allocator)
+        self.value.get_local::<JsRegExp>()
+    }
+    
+    pub fn as_raw(&self) -> JsRawValue {
+        let value = if self.ty.is_ptr() {
+            Data::new_ptr(self.value.get_local::<()>())
+        } else {
+            Data {
+                data: self.value.data
+            }
+        };
+        
+        JsRawValue {
+            ty: self.ty,
+            value: value
+        }
     }
     
     // 9.1 ToPrimitive
-    pub fn to_primitive(&self, env: &mut JsEnv, hint: JsPreferredType) -> JsResult<Local<JsValue>> {
+    pub fn to_primitive(&self, env: &mut JsEnv, hint: JsPreferredType) -> JsResult<JsValue> {
         match self.ty() {
             JsType::Object => self.default_value(env, hint),
             _ => Ok(*self)
@@ -288,7 +361,7 @@ impl Local<JsValue> {
                 let value = self.unwrap_number();
                 !(value == 0.0 || value.is_nan())
             }
-            JsType::String => self.get_ptr::<JsString>().chars().len() > 0,
+            JsType::String => self.value.get_local::<JsString>().chars().len() > 0,
             JsType::Object => true,
             _ => panic!("unexpected type")
         }
@@ -315,7 +388,7 @@ impl Local<JsValue> {
     fn get_number_from_string(&self, env: &JsEnv) -> JsResult<f64> {
         // TODO #67: Use DecimalMatcher.
         
-        let value = self.unwrap_string(env).to_string();
+        let value = self.unwrap_string().to_string();
         let mut reader = StringReader::new("", &value);
         
         if let Ok(mut lexer) = Lexer::new(&mut reader, env.ir.interner(), LexerMode::Runtime) {
@@ -410,7 +483,7 @@ impl Local<JsValue> {
     }
     
     // Taken from http://mxr.mozilla.org/mozilla-central/source/js/public/Conversions.h#255.
-    fn f64_to_u32(number: f64) -> u32 {
+    pub fn f64_to_u32(number: f64) -> u32 {
         let bits = unsafe { transmute::<_, u64>(number) };
         
         // Extract the exponent component.  (Be careful here!  It's not technically
@@ -544,7 +617,7 @@ impl Local<JsValue> {
                 let result = format_number(number, 10, NumberFormatStyle::Regular, 0);
                 JsString::from_str(env, &result)
             }
-            JsType::String => self.unwrap_string(env),
+            JsType::String => self.unwrap_string(),
             JsType::Object => {
                 let result = try!(self.to_primitive(env, JsPreferredType::String));
                 try!(result.to_string(env))
@@ -556,7 +629,7 @@ impl Local<JsValue> {
     }
     
     // 9.9 ToObject
-    pub fn to_object(&self, env: &mut JsEnv) -> JsResult<Local<JsValue>> {
+    pub fn to_object(&self, env: &mut JsEnv) -> JsResult<JsValue> {
         match self.ty {
             JsType::Null | JsType::Undefined => Err(JsError::new_type(env, ::errors::TYPE_INVALID)),
             JsType::String => {
@@ -574,7 +647,7 @@ impl Local<JsValue> {
                 
                 let constructor = try!(env.handle(JsHandle::Global).get(env, class));
                 let object = try!(constructor.construct(env, Vec::new()));
-                object.unwrap_object(env).set_value(*self);
+                object.unwrap_object().set_value(*self);
                 Ok(object)
             }
             JsType::Object => Ok(*self),
@@ -592,165 +665,193 @@ impl Local<JsValue> {
     }
 }
 
+macro_rules! delegate {
+    ( $target:expr, $method:ident ( $( $arg:expr ),* ) ) => {
+        match $target.ty() {
+            JsType::Undefined => JsUndefined.$method( $( $arg ),* ),
+            JsType::Null => JsNull.$method( $( $arg ),* ),
+            JsType::Number => JsNumber::new($target.unwrap_number()).$method( $( $arg ),* ),
+            JsType::Boolean => JsBoolean::new($target.unwrap_bool()).$method( $( $arg ),* ),
+            JsType::Object => $target.unwrap_object().$method( $( $arg ),* ),
+            JsType::String => $target.unwrap_string().$method( $( $arg ),* ),
+            _ => panic!("unexpected type")
+        }
+    };
+    ( $target:expr, $env:expr, $method:ident ( $( $arg:expr ),* ) ) => {
+        match $target.ty() {
+            JsType::Undefined => JsUndefined.$method( $( $arg ),* ),
+            JsType::Null => JsNull.$method( $( $arg ),* ),
+            JsType::Number => JsNumber::new($target.unwrap_number()).$method( $( $arg ),* ),
+            JsType::Boolean => JsBoolean::new($target.unwrap_bool()).$method( $( $arg ),* ),
+            JsType::Object => $target.unwrap_object().$method( $( $arg ),* ),
+            JsType::String => $target.unwrap_string().$method( $( $arg ),* ),
+            _ => panic!("unexpected type")
+        }
+    }
+}
+
+impl JsItem for JsValue {
+    fn as_value(&self) -> JsValue {
+        *self
+    }
+    
+    fn get_own_property(&self, env: &JsEnv, property: Name) -> Option<JsDescriptor> {
+        delegate!(self, env, get_own_property(env, property))
+    }
+    
+    fn get_property(&self, env: &JsEnv, property: Name) -> Option<JsDescriptor> {
+        delegate!(self, env, get_property(env, property))
+    }
+    
+    fn get(&self, env: &mut JsEnv, property: Name) -> JsResult<JsValue> {
+        delegate!(self, env, get(env, property))
+    }
+    
+    fn can_put(&self, env: &JsEnv, property: Name) -> bool {
+        delegate!(self, env, can_put(env, property))
+    }
+    
+    fn put(&mut self, env: &mut JsEnv, property: Name, value: JsValue, throw: bool) -> JsResult<()> {
+        delegate!(self, env, put(env, property, value, throw))
+    }
+    
+    fn has_property(&self, env: &JsEnv, property: Name) -> bool {
+        delegate!(self, env, has_property(env, property))
+    }
+    
+    fn delete(&mut self, env: &mut JsEnv, property: Name, throw: bool) -> JsResult<bool> {
+        delegate!(self, env, delete(env, property, throw))
+    }
+    
+    fn default_value(&self, env: &mut JsEnv, hint: JsPreferredType) -> JsResult<JsValue> {
+        delegate!(self, env, default_value(env, hint))
+    }
+    
+    fn define_own_property(&mut self, env: &mut JsEnv, property: Name, descriptor: JsDescriptor, throw: bool) -> JsResult<bool> {
+        delegate!(self, env, define_own_property(env, property, descriptor, throw))
+    }
+    
+    fn is_callable(&self) -> bool  {
+        delegate!(self, is_callable())
+    }
+    
+    fn call(&self, env: &mut JsEnv, this: JsValue, args: Vec<JsValue>, strict: bool) -> JsResult<JsValue>  {
+        delegate!(self, env, call(env, this, args, strict))
+    }
+    
+    fn can_construct(&self) -> bool  {
+        delegate!(self, can_construct())
+    }
+    
+    fn construct(&self, env: &mut JsEnv, args: Vec<JsValue>) -> JsResult<JsValue>  {
+        delegate!(self, env, construct(env, args))
+    }
+    
+    fn has_prototype(&self) -> bool  {
+        delegate!(self, has_prototype())
+    }
+    
+    fn prototype(&self, env: &JsEnv) -> Option<JsValue>  {
+        delegate!(self, env, prototype(env))
+    }
+    
+    fn set_prototype(&mut self, prototype: Option<JsValue>)  {
+        delegate!(self, set_prototype(prototype))
+    }
+    
+    fn has_class(&self) -> bool  {
+        delegate!(self, has_class())
+    }
+    
+    fn class(&self) -> Option<Name>  {
+        delegate!(self, class())
+    }
+    
+    fn set_class(&mut self, class: Option<Name>)  {
+        delegate!(self, set_class(class))
+    }
+    
+    fn is_extensible(&self) -> bool  {
+        delegate!(self, is_extensible())
+    }
+    
+    fn has_instance(&self, env: &mut JsEnv, object: JsValue) -> JsResult<bool>  {
+        delegate!(self, env, has_instance(env, object))
+    }
+    
+    fn scope(&self, env: &JsEnv) -> Option<Local<JsScope>>  {
+        delegate!(self, env, scope(env))
+    }
+    
+    fn set_scope(&mut self, scope: Option<Local<JsScope>>) {
+        delegate!(self, set_scope(scope))
+    }
+}
+
 #[derive(Copy, Clone, PartialEq, Debug)]
-struct JsRawValue {
+struct LocalData {
     data: u64
 }
 
-impl JsRawValue {
-    fn new() -> JsRawValue {
-        JsRawValue {
+impl LocalData {
+    fn new() -> LocalData {
+        LocalData {
             data: 0
         }
     }
     
-    fn new_number(value: f64) -> JsRawValue {
-        let mut result = JsRawValue::new();
-        result.set_number(value);
-        result
-    }
-    
-    fn new_bool(value: bool) -> JsRawValue {
-        JsRawValue {
-            data: if value { 1 } else { 0 }
+    fn new_number(value: f64) -> LocalData {
+        LocalData {
+            data: unsafe { transmute(value) }
         }
     }
     
-    fn new_ptr<T, U: AsPtr<T>>(value: U) -> JsRawValue {
-        let mut result = JsRawValue::new();
-        result.set_ptr(value.as_ptr());
-        result
+    fn new_bool(value: bool) -> LocalData {
+        LocalData {
+            data: unsafe { transmute::<_, u8>(value) as u64 }
+        }
+    }
+    
+    fn new_local<T>(value: Local<T>) -> LocalData {
+        LocalData {
+            data: unsafe { transmute(value) }
+        }
     }
     
     fn get_number(&self) -> f64 {
         unsafe { transmute(self.data) }
     }
     
-    fn set_number(&mut self, value: f64) {
-        unsafe { self.data = transmute(value); }
-    }
-    
     fn get_bool(&self) -> bool {
-        self.data != 0
+        unsafe { transmute(self.data as u8) }
     }
     
-    fn get_ptr<T>(&self) -> Ptr<T> {
-        Ptr::from_ptr(self.data as ptr_t)
-    }
-    
-    fn set_ptr<T>(&mut self, value: Ptr<T>) {
-        self.data = value.as_ptr().ptr() as u64
-    }
-}
-
-impl JsEnv {
-    pub fn new_value(&self) -> Local<JsValue> {
-        self.heap.alloc_local(GC_VALUE)
-    }
-    
-    pub fn new_undefined(&self) -> Local<JsValue> {
-        self.new_value()
-    }
-    
-    pub fn new_null(&self) -> Local<JsValue> {
-        let mut result = self.new_value();
-        
-        *result = JsValue::new_null();
-        
-        result
-    }
-    
-    pub fn new_number(&self, value: f64) -> Local<JsValue> {
-        let mut result = self.new_value();
-        
-        *result = JsValue::new_number(value);
-        
-        result
-    }
-    
-    pub fn new_bool(&self, value: bool) -> Local<JsValue> {
-        let mut result = self.new_value();
-        
-        *result = JsValue::new_bool(value);
-        
-        result
-    }
-    
-    pub fn new_string(&self, value: Local<JsString>) -> Local<JsValue> {
-        let mut result = self.new_value();
-        
-        *result = JsValue {
-            ty: JsType::String,
-            value: JsRawValue::new_ptr(value)
-        };
-        
-        result
-    }
-    
-    pub fn new_object(&self, value: Local<JsObject>) -> Local<JsValue> {
-        let mut result = self.new_value();
-        
-        *result = JsValue {
-            ty: JsType::Object,
-            value: JsRawValue::new_ptr(value)
-        };
-        
-        result
-    }
-    
-    pub fn new_iterator(&self, value: Local<JsIterator>) -> Local<JsValue> {
-        let mut result = self.new_value();
-        
-        *result = JsValue {
-            ty: JsType::Iterator,
-            value: JsRawValue::new_ptr(value)
-        };
-        
-        result
-    }
-    
-    pub fn new_scope(&self, value: Local<JsScope>) -> Local<JsValue> {
-        let mut result = self.new_value();
-        
-        *result = JsValue {
-            ty: JsType::Scope,
-            value: JsRawValue::new_ptr(value)
-        };
-        
-        result
-    }
-    
-    pub fn new_regexp(&self, value: Local<JsRegExp>) -> Local<JsValue> {
-        let mut result = self.new_value();
-        
-        *result = JsValue {
-            ty: JsType::RegExp,
-            value: JsRawValue::new_ptr(value)
-        };
-        
-        result
+    fn get_local<T>(&self) -> Local<T> {
+        unsafe { transmute(self.data) }
     }
 }
 
 pub unsafe fn validate_walker_for_value(walker: &GcWalker) {
-    let mut object : Box<JsValue> = Box::new(zeroed());
+    let mut object : Box<JsRawValue> = Box::new(zeroed());
     let ptr = transmute::<_, ptr_t>(&*object);
     
     validate_walker_for_embedded_value(walker, ptr, GC_VALUE, 0, &mut *object);
+    
+    assert_eq!(size_of::<JsRawValue>(), 16);
 }
 
-pub unsafe fn validate_walker_for_embedded_value(walker: &GcWalker, ptr: ptr_t, ty: u32, offset: u32, object: *mut JsValue) {
+pub unsafe fn validate_walker_for_embedded_value(walker: &GcWalker, ptr: ptr_t, ty: u32, offset: u32, object: *mut JsRawValue) {
     (*object).ty = JsType::Boolean;
     validate_walker_field(walker, ty, ptr, false);
     (*object).ty = JsType::Undefined;
     
-    (*object).value = JsRawValue { data: 1 };
+    (*object).value = Data { data: 1 };
     validate_walker_field_at(walker, ty, ptr, false, offset + 1);
-    (*object).value = JsRawValue { data: 0 };
+    (*object).value = Data { data: 0 };
     
     (*object).ty = JsType::String;
-    (*object).value = JsRawValue { data: 1 };
+    (*object).value = Data { data: 1 };
     validate_walker_field_at(walker, ty, ptr, true, offset + 1);
     
-    *object = transmute(zeroed::<JsValue>());
+    *object = transmute(zeroed::<JsRawValue>());
 }

--- a/src/rt/walker.rs
+++ b/src/rt/walker.rs
@@ -1,5 +1,5 @@
 use gc::{GcWalker, GcWalk, GcFinalize, GcRootWalker, ptr_t};
-use rt::{JsType, JsRegExp};
+use rt::{JsType, JsRegExp, JsObject};
 use rt::{GC_ARRAY_STORE, GC_ENTRY, GC_HASH_STORE, GC_ITERATOR, GC_OBJECT, GC_REGEXP};
 use rt::{GC_SCOPE, GC_STRING, GC_U16, GC_U32, GC_VALUE, GC_SPARSE_ARRAY, GC_ARRAY_CHUNK};
 use rt::stack::Stack;
@@ -59,7 +59,7 @@ impl GcWalker for Walker {
                 GC_OBJECT => {
                     match index {
                         3 if is_value_ptr(ptr, 2) => GcWalk::Pointer,
-                        12 | 13 | 15 => GcWalk::Pointer,
+                        6 | 7 | 9 => GcWalk::Pointer,
                         _ => GcWalk::Skip
                     }
                 }
@@ -116,6 +116,12 @@ impl GcWalker for Walker {
                 GC_REGEXP => {
                     let regex = transmute::<_, *mut JsRegExp>(ptr);
                     (&mut *regex).finalize();
+                    
+                    GcFinalize::Finalized
+                }
+                GC_OBJECT => {
+                    let object = transmute::<_, *mut JsObject>(ptr);
+                    (&mut *object).finalize();
                     
                     GcFinalize::Finalized
                 }

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -2,7 +2,7 @@ use util::interner::StrInterner;
 use util::interner::RcStr;
 use std::fmt;
 use std::ops::Deref;
-use std::{i32, u32};
+use std::{i32, u32, i64};
 
 pub mod reader;
 pub mod lexer;
@@ -40,6 +40,8 @@ impl Span {
         }
     }
 }
+
+pub const INVALID_NAME : Name = Name(i64::MAX);
 
 #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Clone, Copy, Debug)]
 pub struct Name(i64);


### PR DESCRIPTION
Memory usage has been improved in a lot of places:

* `JsFn` is now a pointer instead of a closure (saves a word);
* The details of `JsFunction` has been moved out of `JsObject` into a native box;
* `JsObject::class` is not an `Option<T>` anymore. Instead a magic value is used to mark it as empty;
* Almost all of the `JsValue` allocations have been removed by creating a `JsValue` version that embeds a `Local<T>` (i.e. rooted pointer).