### PR TITLE
Optimized memory

### DIFF
--- a/src/contrib/test262.rs
+++ b/src/contrib/test262.rs
@@ -296,8 +296,7 @@ fn run_safe(file: String) {
         Err(error) => {
             let _scope = env.new_local_scope();
             
-            let error = error.as_runtime(&mut env);
-            let error = error.as_local(&env);
+            let error = error.as_runtime(&mut env).as_value(&env);
             
             let error = if let Ok(error) = error.to_string(&mut env) {
                 let mut error = error.to_string();

--- a/src/rt/boolean.rs
+++ b/src/rt/boolean.rs
@@ -1,5 +1,4 @@
 use rt::{JsItem, JsEnv, JsValue, JsHandle};
-use gc::Local;
 
 pub struct JsBoolean {
     value: bool
@@ -14,15 +13,15 @@ impl JsBoolean {
 }
 
 impl JsItem for JsBoolean {
-    fn as_value(&self, env: &JsEnv) -> Local<JsValue> {
-        env.new_bool(self.value)
+    fn as_value(&self) -> JsValue {
+        JsValue::new_bool(self.value)
     }
     
-    fn has_prototype(&self, _: &JsEnv) -> bool {
+    fn has_prototype(&self) -> bool {
         true
     }
     
-    fn prototype(&self, env: &JsEnv) -> Option<Local<JsValue>> {
-        Some(env.handle(JsHandle::Boolean).as_value(env))
+    fn prototype(&self, env: &JsEnv) -> Option<JsValue> {
+        Some(env.handle(JsHandle::Boolean).as_value())
     }
 }

--- a/src/rt/env/boolean.rs
+++ b/src/rt/env/boolean.rs
@@ -1,24 +1,23 @@
 use ::{JsResult, JsError};
 use rt::{JsEnv, JsArgs, JsValue, JsFnMode, JsItem, JsType, JsString};
-use gc::*;
 use syntax::token::name;
 
 // 15.6.1 The Boolean Constructor Called as a Function
 // 15.6.2 The Boolean Constructor
-pub fn Boolean_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Boolean_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = if args.argc > 0 {
         args.arg(env, 0).to_boolean()
     } else {
         false
     };
     
-    let arg = env.new_bool(arg);
+    let arg = JsValue::new_bool(arg);
     
     if mode.construct() {
         let this_arg = args.this(env);
-        let mut this = this_arg.unwrap_object(env);
+        let mut this = this_arg.unwrap_object();
         
-        this.set_class(env, Some(name::BOOLEAN_CLASS));
+        this.set_class(Some(name::BOOLEAN_CLASS));
         this.set_value(arg);
         
         Ok(this_arg)
@@ -27,11 +26,11 @@ pub fn Boolean_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsR
     }
 }
 
-fn get_bool_value(env: &mut JsEnv, this: Local<JsValue>) -> JsResult<bool> {
+fn get_bool_value(env: &mut JsEnv, this: JsValue) -> JsResult<bool> {
     match this.ty() {
         JsType::Boolean => Ok(this.unwrap_bool()),
-        JsType::Object if this.class(env) == Some(name::BOOLEAN_CLASS) => {
-            let this = this.unwrap_object(env);
+        JsType::Object if this.class() == Some(name::BOOLEAN_CLASS) => {
+            let this = this.unwrap_object();
             
             Ok(this.value(env).unwrap_bool())
         }
@@ -40,19 +39,19 @@ fn get_bool_value(env: &mut JsEnv, this: Local<JsValue>) -> JsResult<bool> {
 }
 
 // 15.6.4.3 Boolean.prototype.valueOf ( )
-pub fn Boolean_valueOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Boolean_valueOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let this_arg = args.this(env);
     let value = try!(get_bool_value(env, this_arg));
     
-    Ok(env.new_bool(value))
+    Ok(JsValue::new_bool(value))
 }
 
 // 15.6.4.2 Boolean.prototype.toString ( )
-pub fn Boolean_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Boolean_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let this_arg = args.this(env);
     let value = try!(get_bool_value(env, this_arg));
     
     let result = if value { "true" } else { "false" };
     
-    Ok(JsString::from_str(env, result).as_value(env))
+    Ok(JsString::from_str(env, result).as_value())
 }

--- a/src/rt/env/console.rs
+++ b/src/rt/env/console.rs
@@ -1,12 +1,11 @@
 use ::JsResult;
 use rt::{JsEnv, JsArgs, JsValue, JsFnMode};
-use gc::*;
 
 // TODO #65
-pub fn console_log(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn console_log(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(args.arg(env, 0).to_string(env)).to_string();
     
     println!("{}", string);
     
-    Ok(env.new_undefined())
+    Ok(JsValue::new_undefined())
 }

--- a/src/rt/env/error.rs
+++ b/src/rt/env/error.rs
@@ -1,28 +1,27 @@
 use ::{JsResult, JsError};
 use rt::{JsEnv, JsArgs, JsValue, JsFnMode, JsItem, JsType, JsString};
-use gc::*;
 use syntax::token::name;
 
-pub fn Error_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Error_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     if !mode.construct() {
         let target_args = args.args(env);
         return args.function(env).construct(env, target_args);
     }
     
     let this = try!(args.this(env).to_object(env));
-    let mut this_obj = this.unwrap_object(env);
-    this_obj.set_class(env, Some(name::ERROR_CLASS));
+    let mut this_obj = this.unwrap_object();
+    this_obj.set_class(Some(name::ERROR_CLASS));
     
     let message = args.arg(env, 0);
     if !message.is_undefined() {
-        let message = try!(message.to_string(env)).as_value(env);
+        let message = try!(message.to_string(env)).as_value();
         try!(this_obj.put(env, name::MESSAGE, message, true));
     }
     
     Ok(this)
 }
 
-pub fn Error_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Error_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let this = args.this(env);
     if this.ty() != JsType::Object {
         Err(JsError::new_type(env, ::errors::TYPE_INVALID))
@@ -50,6 +49,6 @@ pub fn Error_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResul
             JsString::from_str(env, &result)
         };
         
-        Ok(result.as_value(env))
+        Ok(result.as_value())
     }
 }

--- a/src/rt/env/json/mod.rs
+++ b/src/rt/env/json/mod.rs
@@ -1,6 +1,5 @@
 use ::JsResult;
 use rt::{JsEnv, JsArgs, JsValue, JsFnMode};
-use gc::*;
 use syntax::reader::StringReader;
 use self::writer::JsonWriter;
 
@@ -9,7 +8,7 @@ mod parser;
 mod writer;
 
 // 15.12.2 parse ( text [ , reviver ] )
-pub fn JSON_parse(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn JSON_parse(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(args.arg(env, 0).to_string(env)).to_string();
     
     let mut reader = StringReader::new("(json)", &string);
@@ -21,6 +20,6 @@ pub fn JSON_parse(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Lo
 }
 
 // 15.12.3 stringify ( value [ , replacer [ , space ] ] )
-pub fn JSON_stringify(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn JSON_stringify(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     try!(JsonWriter::new(env, mode, args)).write()
 }

--- a/src/rt/env/json/parser.rs
+++ b/src/rt/env/json/parser.rs
@@ -2,7 +2,6 @@ use syntax::Name;
 use ::{JsResult, JsError};
 use rt::{JsEnv, JsValue, JsDescriptor, JsString, JsItem};
 use rt::env::json::lexer::{Lexer, Token, Lit};
-use gc::Local;
 
 pub struct Parser<'a> {
     lexer: &'a mut Lexer<'a>,
@@ -59,7 +58,7 @@ impl<'a> Parser<'a> {
         Err(JsError::Parse(message.to_string()))
     }
     
-    pub fn parse_json(env: &'a mut JsEnv, lexer: &'a mut Lexer<'a>) -> JsResult<Local<JsValue>> {
+    pub fn parse_json(env: &'a mut JsEnv, lexer: &'a mut Lexer<'a>) -> JsResult<JsValue> {
         let mut parser = Parser {
             lexer: lexer,
             env: env
@@ -74,14 +73,14 @@ impl<'a> Parser<'a> {
         }
     }
     
-    fn parse_value(&mut self) -> JsResult<Local<JsValue>> {
+    fn parse_value(&mut self) -> JsResult<JsValue> {
         match try!(self.next()) {
             Token::Literal(lit) => {
                 match lit {
-                    Lit::Null => Ok(self.env.new_null()),
-                    Lit::Boolean(value) => Ok(self.env.new_bool(value)),
-                    Lit::String(value) => Ok(JsString::from_str(self.env, &value).as_value(self.env)),
-                    Lit::Number(value) => Ok(self.env.new_number(value))
+                    Lit::Null => Ok(JsValue::new_null()),
+                    Lit::Boolean(value) => Ok(JsValue::new_bool(value)),
+                    Lit::String(value) => Ok(JsString::from_str(self.env, &value).as_value()),
+                    Lit::Number(value) => Ok(JsValue::new_number(value))
                 }
             }
             Token::OpenBrace => self.parse_object(),
@@ -90,7 +89,7 @@ impl<'a> Parser<'a> {
         }
     }
     
-    fn parse_object(&mut self) -> JsResult<Local<JsValue>> {
+    fn parse_object(&mut self) -> JsResult<JsValue> {
         let mut object = self.env.create_object();
         
         if !try!(self.consume(Token::CloseBrace)) {
@@ -114,10 +113,10 @@ impl<'a> Parser<'a> {
             }
         }
         
-        Ok(object.as_value(self.env))
+        Ok(object.as_value())
     }
     
-    fn parse_array(&mut self) -> JsResult<Local<JsValue>> {
+    fn parse_array(&mut self) -> JsResult<JsValue> {
         let mut array = self.env.create_array();
         let mut offset = 0;
         
@@ -136,6 +135,6 @@ impl<'a> Parser<'a> {
             }
         }
     
-        Ok(array.as_value(self.env))
+        Ok(array.as_value())
     }
 }

--- a/src/rt/env/math.rs
+++ b/src/rt/env/math.rs
@@ -2,88 +2,87 @@ extern crate rand;
 
 use ::JsResult;
 use rt::{JsEnv, JsArgs, JsValue, JsFnMode, JsType};
-use gc::*;
 use std::f64;
 use self::rand::random;
 
 // 15.8.2.1 abs (x)
-pub fn Math_abs(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_abs(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
-    Ok(env.new_number(arg.abs()))
+    Ok(JsValue::new_number(arg.abs()))
 }
 
 // 15.8.2.2 acos (x)
-pub fn Math_acos(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_acos(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.acos()))
+    Ok(JsValue::new_number(arg.acos()))
 }
 
 // 15.8.2.3 asin (x)
-pub fn Math_asin(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_asin(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.asin()))
+    Ok(JsValue::new_number(arg.asin()))
 }
 
 // 15.8.2.4 atan (x)
-pub fn Math_atan(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_atan(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.atan()))
+    Ok(JsValue::new_number(arg.atan()))
 }
 
 // 15.8.2.5 atan2 (y, x)
-pub fn Math_atan2(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_atan2(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let y = try!(args.arg(env, 0).to_number(env));
     let x = try!(args.arg(env, 1).to_number(env));
     
-    Ok(env.new_number(y.atan2(x)))
+    Ok(JsValue::new_number(y.atan2(x)))
 }
 
 // 15.8.2.6 ceil (x)
-pub fn Math_ceil(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_ceil(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.ceil()))
+    Ok(JsValue::new_number(arg.ceil()))
 }
 
 // 15.8.2.7 cos (x)
-pub fn Math_cos(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_cos(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.cos()))
+    Ok(JsValue::new_number(arg.cos()))
 }
 
 // 15.8.2.8 exp (x)
-pub fn Math_exp(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_exp(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.exp()))
+    Ok(JsValue::new_number(arg.exp()))
 }
 
 // 15.8.2.9 floor (x)
-pub fn Math_floor(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_floor(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.floor()))
+    Ok(JsValue::new_number(arg.floor()))
 }
 
 // 15.8.2.10 log (x)
-pub fn Math_log(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_log(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.ln()))
+    Ok(JsValue::new_number(arg.ln()))
 }
 
 // 15.8.2.11 max ( [ value1 [ , value2 [ , … ] ] ] )
-pub fn Math_max(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_max(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let mut result = None;
     
     for i in 0..args.argc {
         let arg = args.arg(env, i);
         if arg.ty() == JsType::Number && arg.unwrap_number().is_nan() {
-            return Ok(env.new_number(f64::NAN));
+            return Ok(JsValue::new_number(f64::NAN));
         }
         
         if let Some(last) = result {
@@ -97,18 +96,18 @@ pub fn Math_max(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Loca
     
     Ok(match result {
         Some(result) => result,
-        _ => env.new_number(f64::NEG_INFINITY)
+        _ => JsValue::new_number(f64::NEG_INFINITY)
     })
 }
 
 // 15.8.2.12 min ( [ value1 [ , value2 [ , … ] ] ] )
-pub fn Math_min(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_min(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let mut result = None;
     
     for i in 0..args.argc {
         let arg = args.arg(env, i);
         if arg.ty() == JsType::Number && arg.unwrap_number().is_nan() {
-            return Ok(env.new_number(f64::NAN));
+            return Ok(JsValue::new_number(f64::NAN));
         }
         
         if let Some(last) = result {
@@ -122,12 +121,12 @@ pub fn Math_min(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Loca
     
     Ok(match result {
         Some(result) => result,
-        _ => env.new_number(f64::INFINITY)
+        _ => JsValue::new_number(f64::INFINITY)
     })
 }
 
 // 15.8.2.13 pow (x, y)
-pub fn Math_pow(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_pow(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let x = try!(args.arg(env, 0).to_number(env));
     let y = try!(args.arg(env, 1).to_number(env));
     
@@ -145,16 +144,16 @@ pub fn Math_pow(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Loca
         x.powf(y)
     };
     
-    Ok(env.new_number(result))
+    Ok(JsValue::new_number(result))
 }
 
 // 15.8.2.14 random ( )
-pub fn Math_random(env: &mut JsEnv, _mode: JsFnMode, _args: JsArgs) -> JsResult<Local<JsValue>> {
-    Ok(env.new_number(random::<f64>()))
+pub fn Math_random(_env: &mut JsEnv, _mode: JsFnMode, _args: JsArgs) -> JsResult<JsValue> {
+    Ok(JsValue::new_number(random::<f64>()))
 }
 
 // 15.8.2.15 round (x)
-pub fn Math_round(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_round(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
     let result = if arg.is_finite() {
@@ -182,26 +181,26 @@ pub fn Math_round(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Lo
         arg
     };
     
-    Ok(env.new_number(result))
+    Ok(JsValue::new_number(result))
 }
 
 // 15.8.2.16 sin (x)
-pub fn Math_sin(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_sin(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.sin()))
+    Ok(JsValue::new_number(arg.sin()))
 }
 
 // 15.8.2.17 sqrt (x)
-pub fn Math_sqrt(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_sqrt(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.sqrt()))
+    Ok(JsValue::new_number(arg.sqrt()))
 }
 
 // 15.8.2.18 tan (x)
-pub fn Math_tan(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn Math_tan(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = try!(args.arg(env, 0).to_number(env));
     
-    Ok(env.new_number(arg.tan()))
+    Ok(JsValue::new_number(arg.tan()))
 }

--- a/src/rt/env/regexp.rs
+++ b/src/rt/env/regexp.rs
@@ -6,20 +6,20 @@ use syntax::Name;
 
 // 15.10.3 The RegExp Constructor Called as a Function
 // 15.10.4 The RegExp Constructor
-pub fn RegExp_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn RegExp_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let pattern = args.arg(env, 0);
     let flags = args.arg(env, 1);
     
     if !mode.construct() {
-        if pattern.class(env) == Some(name::REGEXP_CLASS) && flags.is_undefined() {
+        if pattern.class() == Some(name::REGEXP_CLASS) && flags.is_undefined() {
             Ok(pattern)
         } else {
             args.function(env).construct(env, vec![pattern, flags])
         }
     } else {
-        let (pattern, flags) = if pattern.class(env) == Some(name::REGEXP_CLASS) {
+        let (pattern, flags) = if pattern.class() == Some(name::REGEXP_CLASS) {
             if flags.is_undefined() {
-                let regexp = pattern.unwrap_object(env).value(env).unwrap_regexp(env);
+                let regexp = pattern.unwrap_object().value(env).unwrap_regexp();
                 
                 (regexp.pattern(env), regexp.flags(env))
             } else {
@@ -78,20 +78,20 @@ pub fn RegExp_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsRe
         ));
         
         let this_arg = args.this(env);
-        let mut this = this_arg.unwrap_object(env);
+        let mut this = this_arg.unwrap_object();
         
-        this.set_class(env, Some(name::REGEXP_CLASS));
-        this.set_value(regexp.as_value(env));
+        this.set_class(Some(name::REGEXP_CLASS));
+        this.set_value(regexp.as_value());
         
-        let value = JsDescriptor::new_value(pattern.as_value(env), false, false, false);
+        let value = JsDescriptor::new_value(pattern.as_value(), false, false, false);
         try!(this.define_own_property(env, name::SOURCE, value, true));
-        let value = JsDescriptor::new_value(env.new_bool(global), false, false, false);
+        let value = JsDescriptor::new_value(JsValue::new_bool(global), false, false, false);
         try!(this.define_own_property(env, name::GLOBAL, value, true));
-        let value = JsDescriptor::new_value(env.new_bool(ignore_case), false, false, false);
+        let value = JsDescriptor::new_value(JsValue::new_bool(ignore_case), false, false, false);
         try!(this.define_own_property(env, name::IGNORE_CASE, value, true));
-        let value = JsDescriptor::new_value(env.new_bool(multiline), false, false, false);
+        let value = JsDescriptor::new_value(JsValue::new_bool(multiline), false, false, false);
         try!(this.define_own_property(env, name::MULTILINE, value, true));
-        let value = JsDescriptor::new_value(env.new_number(0.0), true, false, false);
+        let value = JsDescriptor::new_value(JsValue::new_number(0.0), true, false, false);
         try!(this.define_own_property(env, name::LAST_INDEX, value, true));
         
         Ok(this_arg)
@@ -101,15 +101,15 @@ pub fn RegExp_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsRe
 fn unwrap_regexp(env: &mut JsEnv, args: &JsArgs) -> JsResult<Local<JsRegExp>> {
     let this = args.this(env);
     
-    if this.class(env) == Some(name::REGEXP_CLASS) {
-        Ok(this.unwrap_object(env).value(env).unwrap_regexp(env))
+    if this.class() == Some(name::REGEXP_CLASS) {
+        Ok(this.unwrap_object().value(env).unwrap_regexp())
     } else {
         Err(JsError::new_type(env, ::errors::TYPE_INVALID))
     }
 }
 
 // 15.10.6.2 RegExp.prototype.exec(string)
-pub fn RegExp_exec(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn RegExp_exec(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let regexp = try!(unwrap_regexp(env, &args));
     let mut this = args.this(env);
     
@@ -131,9 +131,9 @@ pub fn RegExp_exec(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<L
     // right. This will be fixed through #79.
     
     if last_index < 0.0 || last_index > length as f64 {
-        let value = env.new_number(0.0);
+        let value = JsValue::new_number(0.0);
         try!(this.put(env, name::LAST_INDEX, value, true));
-        return Ok(env.new_null());
+        return Ok(JsValue::new_null());
     }
     
     let last_index = last_index as usize;
@@ -148,55 +148,55 @@ pub fn RegExp_exec(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<L
         let end_index = end_index + last_index;
         
         if global {
-            let value = env.new_number(end_index as f64);
+            let value = JsValue::new_number(end_index as f64);
             try!(this.put(env, name::LAST_INDEX, value, true));
         }
         
         let mut result = env.create_array();
         
-        let value = JsDescriptor::new_simple_value(env.new_number(start_index as f64));
+        let value = JsDescriptor::new_simple_value(JsValue::new_number(start_index as f64));
         try!(result.define_own_property(env, name::INDEX, value, true));
         
-        let value = JsDescriptor::new_simple_value(input.as_value(env));
+        let value = JsDescriptor::new_simple_value(input.as_value());
         try!(result.define_own_property(env, name::INPUT, value, true));
         
         // Length is the same as capture.len() because that includes the
         // complete match as the first entry.
         let value = JsDescriptor {
-            value: Some(env.new_number(capture.len() as f64)),
+            value: Some(JsValue::new_number(capture.len() as f64)),
             ..JsDescriptor::default()
         };
         try!(result.define_own_property(env, name::LENGTH, value, true));
         
-        let matched_substr = JsString::from_str(env, &string[start_index..end_index]).as_value(env);
+        let matched_substr = JsString::from_str(env, &string[start_index..end_index]).as_value();
         let value = JsDescriptor::new_simple_value(matched_substr);
         try!(result.define_own_property(env, Name::from_index(0), value, true));
         
         for i in 1..capture.len() {
             if let Some((capture_start, capture_end)) = capture.pos(i) {
-                let capture_i = JsString::from_str(env, &string[(capture_start + last_index)..(capture_end + last_index)]).as_value(env);
+                let capture_i = JsString::from_str(env, &string[(capture_start + last_index)..(capture_end + last_index)]).as_value();
                 let value = JsDescriptor::new_simple_value(capture_i);
                 try!(result.define_own_property(env, Name::from_index(i), value, true));
             }
         }
         
-        Ok(result.as_value(env))
+        Ok(result.as_value())
     } else {
-        let value = env.new_number(0.0);
+        let value = JsValue::new_number(0.0);
         try!(this.put(env, name::LAST_INDEX, value, true));
-        Ok(env.new_null())
+        Ok(JsValue::new_null())
     }
 }
 
 // 15.10.6.3 RegExp.prototype.test(string)
-pub fn RegExp_test(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn RegExp_test(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let result = try!(RegExp_exec(env, mode, args));
     
-    Ok(env.new_bool(!result.is_null()))
+    Ok(JsValue::new_bool(!result.is_null()))
 }
 
 // 15.10.6.4 RegExp.prototype.toString()
-pub fn RegExp_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn RegExp_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let regexp = try!(unwrap_regexp(env, &args));
     
     let mut result = String::new();
@@ -215,5 +215,5 @@ pub fn RegExp_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResu
         result.push('m');
     }
     
-    Ok(JsString::from_str(env, &result).as_value(env))
+    Ok(JsString::from_str(env, &result).as_value())
 }

--- a/src/rt/env/string/mod.rs
+++ b/src/rt/env/string/mod.rs
@@ -21,11 +21,11 @@ fn get_this_string(env: &mut JsEnv, args: &JsArgs) -> JsResult<Local<JsString>> 
 // 15.5.1 The String Constructor Called as a Function
 // 15.5.2 The String Constructor
 // 15.5.5.1 length
-pub fn String_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let arg = if args.argc > 0 {
-        try!(args.arg(env, 0).to_string(env)).as_value(env)
+        try!(args.arg(env, 0).to_string(env)).as_value()
     } else {
-        JsString::from_str(env, "").as_value(env)
+        JsString::from_str(env, "").as_value()
     };
     
     if !mode.construct() {
@@ -33,28 +33,28 @@ pub fn String_constructor(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsRe
     }
     
     let this_arg = args.this(env);
-    let mut object = this_arg.unwrap_object(env);
+    let mut object = this_arg.unwrap_object();
     
-    object.set_prototype(env, Some(env.handle(JsHandle::String).as_value(env)));
-    object.set_class(env, Some(name::STRING_CLASS));
+    object.set_prototype(Some(env.handle(JsHandle::String).as_value()));
+    object.set_class(Some(name::STRING_CLASS));
     object.set_value(arg);
     
-    let value = env.new_number(arg.unwrap_string(env).chars().len() as f64);
+    let value = JsValue::new_number(arg.unwrap_string().chars().len() as f64);
     try!(object.define_own_property(env, name::LENGTH, JsDescriptor::new_value(value, false, false, false), false));
     
     Ok(this_arg)
 }
 
 // 15.5.4.2 String.prototype.toString ( )
-pub fn String_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let this_arg = args.this(env);
     
     match this_arg.ty() {
         JsType::String => Ok(this_arg),
         JsType::Object => {
-            let object = this_arg.unwrap_object(env);
+            let object = this_arg.unwrap_object();
             
-            if object.class(env) == Some(name::STRING_CLASS) {
+            if object.class() == Some(name::STRING_CLASS) {
                 // This is safe because the constructor always sets the value.
                 Ok(object.value(env))
             } else {
@@ -66,15 +66,15 @@ pub fn String_toString(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResu
 }
 
 // 15.5.4.3 String.prototype.valueOf ( )
-pub fn String_valueOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_valueOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let this_arg = args.this(env);
     
     match this_arg.ty() {
         JsType::String => Ok(this_arg),
         JsType::Object => {
-            let object = this_arg.unwrap_object(env);
+            let object = this_arg.unwrap_object();
             
-            if object.class(env) == Some(name::STRING_CLASS) {
+            if object.class() == Some(name::STRING_CLASS) {
                 // This is safe because the constructor always sets the value.
                 Ok(object.value(env))
             } else {
@@ -86,18 +86,18 @@ pub fn String_valueOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResul
 }
 
 // 15.5.3.2 String.fromCharCode ( [ char0 [ , char1 [ , … ] ] ] )
-pub fn String_fromCharCode(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_fromCharCode(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let mut chars = Vec::new();
     
     for i in 0..args.argc {
         chars.push(try!(args.arg(env, i).to_uint16(env)));
     }
     
-    Ok(env.new_string(JsString::from_u16(env, &chars)))
+    Ok(JsString::from_u16(env, &chars).as_value())
 }
 
 // 15.5.4.4 String.prototype.charAt (pos)
-pub fn String_charAt(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_charAt(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let this = try!(get_this_string(env, &args));
     let chars = this.chars();
     let position = try!(args.arg(env, 0).to_integer(env)) as i32;
@@ -108,11 +108,11 @@ pub fn String_charAt(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult
         char::from_u32(chars[position as usize] as u32).unwrap().to_string()
     };
     
-    Ok(JsString::from_str(env, &result).as_value(env))
+    Ok(JsString::from_str(env, &result).as_value())
 }
 
 // 15.5.4.5 String.prototype.charCodeAt (pos)
-pub fn String_charCodeAt(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_charCodeAt(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let this = try!(get_this_string(env, &args));
     let chars = this.chars();
     let position = try!(args.arg(env, 0).to_integer(env)) as i32;
@@ -123,19 +123,19 @@ pub fn String_charCodeAt(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsRe
         chars[position as usize] as f64
     };
     
-    Ok(env.new_number(result))
+    Ok(JsValue::new_number(result))
 }
 
 // 15.5.4.7 String.prototype.indexOf (searchString, position)
 // 15.5.4.8 String.prototype.lastIndexOf (searchString, position)
-fn index_of(env: &mut JsEnv, args: JsArgs, reverse: bool) -> JsResult<Local<JsValue>> {
+fn index_of(env: &mut JsEnv, args: JsArgs, reverse: bool) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args));
     let search = try!(args.arg(env, 0).to_string(env));
     
     let len = string.chars().len();
     let search_len = search.chars().len();
     if len == 0 || search_len > len {
-        return Ok(env.new_number(-1.0));
+        return Ok(JsValue::new_number(-1.0));
     }
     
     let position = args.arg(env, 1);
@@ -148,7 +148,7 @@ fn index_of(env: &mut JsEnv, args: JsArgs, reverse: bool) -> JsResult<Local<JsVa
         };
         
         if position >= len as i32 {
-            return Ok(env.new_number(-1.0));
+            return Ok(JsValue::new_number(-1.0));
         }
         
         (max(position, 0) as usize, len)
@@ -160,7 +160,7 @@ fn index_of(env: &mut JsEnv, args: JsArgs, reverse: bool) -> JsResult<Local<JsVa
         };
         
         if position < 0 {
-            return Ok(env.new_number(-1.0));
+            return Ok(JsValue::new_number(-1.0));
         }
         
         (0, position as usize)
@@ -199,21 +199,21 @@ fn index_of(env: &mut JsEnv, args: JsArgs, reverse: bool) -> JsResult<Local<JsVa
         }
     }
     
-    Ok(env.new_number(result as f64))
+    Ok(JsValue::new_number(result as f64))
 }
 
 // 15.5.4.7 String.prototype.indexOf (searchString, position)
-pub fn String_indexOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_indexOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     index_of(env, args, false)
 }
 
 // 15.5.4.8 String.prototype.lastIndexOf (searchString, position)
-pub fn String_lastIndexOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_lastIndexOf(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     index_of(env, args, true)
 }
 
 // 15.5.4.15 String.prototype.substring (start, end)
-pub fn String_substring(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_substring(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args));
     let len = string.chars().len() as f64;
     
@@ -233,38 +233,38 @@ pub fn String_substring(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsRes
     
     let result = JsString::from_u16(env, &string.chars()[(from as usize)..(to as usize)]);
     
-    Ok(result.as_value(env))
+    Ok(result.as_value())
 }
 
 // 15.5.4.16 String.prototype.toLowerCase ( )
-pub fn String_toLowerCase(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_toLowerCase(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args)).to_string().to_lowercase();
     let string = JsString::from_str(env, &string);
     
-    Ok(string.as_value(env))
+    Ok(string.as_value())
 }
 
 // 15.5.4.17 String.prototype.toLocaleLowerCase ( )
-pub fn String_toLocaleLowerCase(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_toLocaleLowerCase(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     String_toLowerCase(env, mode, args)
 }
 
 // 15.5.4.18 String.prototype.toUpperCase ( )
-pub fn String_toUpperCase(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_toUpperCase(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args)).to_string().to_uppercase();
     let string = JsString::from_str(env, &string);
     
-    Ok(string.as_value(env))
+    Ok(string.as_value())
 }
 
 // 15.5.4.19 String.prototype.toLocaleUpperCase ( )
-pub fn String_toLocaleUpperCase(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_toLocaleUpperCase(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     String_toUpperCase(env, mode, args)
 }
 
 
 // 15.5.4.6 String.prototype.concat ( [ string1 [ , string2 [ , … ] ] ] )
-pub fn String_concat(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_concat(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args));
     
     let mut strings = Vec::with_capacity(args.argc + 1);
@@ -275,12 +275,12 @@ pub fn String_concat(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult
         strings.push(arg);
     }
     
-    Ok(JsString::concat(env, &strings).as_value(env))
+    Ok(JsString::concat(env, &strings).as_value())
 }
 
 
 // 15.5.4.9 String.prototype.localeCompare (that)
-pub fn String_localeCompare(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_localeCompare(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args));
     let that = try!(args.arg(env, 0).to_string(env));
     
@@ -295,10 +295,10 @@ pub fn String_localeCompare(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> J
         let that_c = that[i];
         
         if string_c < that_c {
-            return Ok(env.new_number(-1.0));
+            return Ok(JsValue::new_number(-1.0));
         }
         if string_c > that_c {
-            return Ok(env.new_number(1.0));
+            return Ok(JsValue::new_number(1.0));
         }
     }
     
@@ -310,28 +310,28 @@ pub fn String_localeCompare(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> J
         0.0
     };
     
-    Ok(env.new_number(result))
+    Ok(JsValue::new_number(result))
 }
 
 // 15.5.4.10 String.prototype.match (regexp)
-pub fn String_match(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
-    let string = try!(get_this_string(env, &args)).as_value(env);
+pub fn String_match(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
+    let string = try!(get_this_string(env, &args)).as_value();
     
     let regex = args.arg(env, 0);
-    let mut rx = if regex.class(env) == Some(name::REGEXP_CLASS) {
+    let mut rx = if regex.class() == Some(name::REGEXP_CLASS) {
         regex
     } else {
         try!(env.handle(JsHandle::RegExpClass).construct(env, vec![regex]))
     };
     
-    let global = rx.unwrap_object(env).value(env).unwrap_regexp(env).global();
+    let global = rx.unwrap_object().value(env).unwrap_regexp().global();
     
     let exec = try!(rx.get(env, name::EXEC));
     
     let result = if !global {
         try!(exec.call(env, rx, vec![string], false))
     } else {
-        let value = env.new_number(0.0);
+        let value = JsValue::new_number(0.0);
         try!(rx.put(env, name::LAST_INDEX, value, true));
         
         let mut array = env.create_array();
@@ -347,7 +347,7 @@ pub fn String_match(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
             
             let this_index = try!(try!(rx.get(env, name::LAST_INDEX)).to_integer(env)) as isize;
             if this_index == previous_last_index {
-                let value = env.new_number((this_index + 1) as f64);
+                let value = JsValue::new_number((this_index + 1) as f64);
                 try!(rx.put(env, name::LAST_INDEX, value, true));
                 previous_last_index = this_index + 1;
             } else {
@@ -366,9 +366,9 @@ pub fn String_match(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
         }
         
         if n == 0 {
-            env.new_null()
+            JsValue::new_null()
         } else {
-            array.as_value(env)
+            array.as_value()
         }
     };
     
@@ -376,22 +376,22 @@ pub fn String_match(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
 }
 
 // 15.5.4.11 String.prototype.replace (searchValue, replaceValue)
-pub fn String_replace(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_replace(env: &mut JsEnv, mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     replacer::Replacer::replace(env, args, mode.strict())
 }
 
 // 15.5.4.12 String.prototype.search (regexp)
-pub fn String_search(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_search(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args));
     
     let regex = args.arg(env, 0);
-    let rx = if regex.class(env) == Some(name::REGEXP_CLASS) {
+    let rx = if regex.class() == Some(name::REGEXP_CLASS) {
         regex
     } else {
         try!(env.handle(JsHandle::RegExpClass).construct(env, vec![regex]))
     };
     
-    let regexp = rx.unwrap_object(env).value(env).unwrap_regexp(env);
+    let regexp = rx.unwrap_object().value(env).unwrap_regexp();
     
     let string = string.to_string();
     
@@ -401,11 +401,11 @@ pub fn String_search(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult
         -1.0
     };
     
-    Ok(env.new_number(result))
+    Ok(JsValue::new_number(result))
 }
 
 // 15.5.4.13 String.prototype.slice (start, end)
-pub fn String_slice(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_slice(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args));
     
     let len = string.chars().len() as f64;
@@ -432,26 +432,26 @@ pub fn String_slice(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
     };
     
     if start >= len {
-        Ok(JsString::from_str(env, "").as_value(env))
+        Ok(JsString::from_str(env, "").as_value())
     } else {
         let span = (end - start).max(0.0);
         
-        Ok(JsString::from_u16(env, &string.chars()[(start as usize)..((start + span) as usize)]).as_value(env))
+        Ok(JsString::from_u16(env, &string.chars()[(start as usize)..((start + span) as usize)]).as_value())
     }
 }
 
 // 15.5.4.14 String.prototype.split (separator, limit)
-pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     struct MatchResult {
         index: usize,
         end_index: usize,
-        captures: Vec<Local<JsValue>>
+        captures: Vec<JsValue>
     }
     
-    fn split_match(env: &mut JsEnv, string: Local<JsValue>, offset: usize, separator: Local<JsValue>) -> JsResult<Option<MatchResult>> {
-        if separator.class(env) == Some(name::REGEXP_CLASS) {
+    fn split_match(env: &mut JsEnv, string: JsValue, offset: usize, separator: JsValue) -> JsResult<Option<MatchResult>> {
+        if separator.class() == Some(name::REGEXP_CLASS) {
             let exec = try!(separator.get(env, name::EXEC));
-            let string = JsString::from_u16(env, &string.unwrap_string(env).chars()[offset..]).as_value(env);
+            let string = JsString::from_u16(env, &string.unwrap_string().chars()[offset..]).as_value();
             let matches = try!(exec.call(env, separator, vec![string], false));
             
             if matches.is_null() {
@@ -475,11 +475,11 @@ pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
                 }))
             }
         } else {
-            let separator = separator.unwrap_string(env);
+            let separator = separator.unwrap_string();
             let separator = separator.chars();
             let length = separator.len();
             
-            let string = string.unwrap_string(env);
+            let string = string.unwrap_string();
             let string = string.chars();
             let string_length = string.len();
             
@@ -502,7 +502,7 @@ pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
     }
     
     let string = try!(get_this_string(env, &args));
-    let string_value = string.as_value(env);
+    let string_value = string.as_value();
     
     let mut array = env.create_array();
     let mut array_length = 0;
@@ -520,17 +520,17 @@ pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
     
     let separator = {
         let separator = args.arg(env, 0);
-        if separator.class(env) == Some(name::REGEXP_CLASS) {
+        if separator.class() == Some(name::REGEXP_CLASS) {
             separator
         } else if separator.is_undefined() {
             separator
         } else {
-            try!(separator.to_string(env)).as_value(env)
+            try!(separator.to_string(env)).as_value()
         }
     };
     
     if limit == 0 {
-        Ok(array.as_value(env))
+        Ok(array.as_value())
     } else {
         if separator.is_undefined() {
             try!(array.define_own_property(
@@ -563,7 +563,7 @@ pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
                         } else {
                             offset = match_result.index;
                             
-                            let part = JsString::from_u16(env, &string.chars()[last_offset..offset]).as_value(env);
+                            let part = JsString::from_u16(env, &string.chars()[last_offset..offset]).as_value();
                             
                             try!(array.define_own_property(
                                 env,
@@ -574,7 +574,7 @@ pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
                             
                             array_length += 1;
                             if array_length == limit as usize {
-                                return Ok(array.as_value(env));
+                                return Ok(array.as_value());
                             }
                             
                             last_offset = match_result.end_index;
@@ -589,7 +589,7 @@ pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
                                 
                                 array_length += 1;
                                 if array_length == limit as usize {
-                                    return Ok(array.as_value(env))
+                                    return Ok(array.as_value())
                                 }
                             }
                             
@@ -599,7 +599,7 @@ pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
                 }
             }
             
-            let remaining = JsString::from_u16(env, &string.chars()[last_offset..string_length]).as_value(env);
+            let remaining = JsString::from_u16(env, &string.chars()[last_offset..string_length]).as_value();
             try!(array.define_own_property(
                 env,
                 Name::from_index(array_length),
@@ -608,12 +608,12 @@ pub fn String_split(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<
             ));
         }
         
-        Ok(array.as_value(env))
+        Ok(array.as_value())
     }
 }
 
 // 15.5.4.20 String.prototype.trim ( )
-pub fn String_trim(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<Local<JsValue>> {
+pub fn String_trim(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<JsValue> {
     let string = try!(get_this_string(env, &args));
     
     let chars = string.chars();
@@ -647,8 +647,8 @@ pub fn String_trim(env: &mut JsEnv, _mode: JsFnMode, args: JsArgs) -> JsResult<L
             end -= 1;
         }
         
-        Ok(JsString::from_u16(env, &chars[start..end]).as_value(env))
+        Ok(JsString::from_u16(env, &chars[start..end]).as_value())
     } else {
-        Ok(JsString::from_str(env, "").as_value(env))
+        Ok(JsString::from_str(env, "").as_value())
     }
 }

--- a/src/rt/iterator.rs
+++ b/src/rt/iterator.rs
@@ -15,15 +15,15 @@ pub struct JsIterator {
 }
 
 impl JsIterator {
-    pub fn new_local(env: &JsEnv, target: Local<JsValue>) -> Local<JsIterator> {
+    pub fn new_local(env: &JsEnv, target: JsValue) -> Local<JsIterator> {
         let mut result = env.heap.alloc_local::<JsIterator>(GC_ITERATOR);
         
         let target = match target.ty() {
-            JsType::Object => target.unwrap_object(env).as_ptr(),
+            JsType::Object => target.unwrap_object().as_ptr(),
             JsType::Null | JsType::Undefined => Ptr::null(),
             _ => {
                 if let Some(prototype) = target.prototype(env) {
-                    prototype.unwrap_object(env).as_ptr()
+                    prototype.unwrap_object().as_ptr()
                 } else {
                     Ptr::null()
                 }
@@ -45,8 +45,8 @@ impl JsIterator {
 }
 
 impl Local<JsIterator> {
-    pub fn as_value(&self, env: &JsEnv) -> Local<JsValue> {
-        env.new_iterator(*self)
+    pub fn as_value(&self) -> JsValue {
+        JsValue::new_iterator(*self)
     }
     
     pub fn next(&mut self, env: &JsEnv) -> bool {
@@ -72,7 +72,7 @@ impl Local<JsIterator> {
                 }
                 JsStoreKey::End => {
                     if let Some(prototype) = target.prototype(env) {
-                        target = prototype.unwrap_object(env);
+                        target = prototype.unwrap_object();
                         
                         self.target = target.as_ptr();
                         self.offset = 0;

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -11,7 +11,7 @@ use std::mem::transmute;
 use std::rc::Rc;
 use std::io;
 
-pub use self::value::JsValue;
+pub use self::value::{JsRawValue, JsValue};
 pub use self::object::{JsObject, JsStoreType};
 pub use self::string::JsString;
 pub use self::null::JsNull;
@@ -110,8 +110,7 @@ impl JsEnv {
         if let Err(error) = env::setup(&mut env) {
             let _scope = env.new_local_scope();
             
-            let error = error.as_runtime(&mut env);
-            let error = error.as_local(&env);
+            let error = error.as_runtime(&mut env).as_value(&env);
             
             let error = if let Ok(error) = error.to_string(&mut env) {
                 error.to_string()
@@ -141,11 +140,11 @@ impl JsEnv {
         self.handles.push(root);
     }
     
-    pub fn run(&mut self, file_name: &str) -> JsResult<Root<JsValue>> {
+    pub fn run(&mut self, file_name: &str) -> JsResult<Root<JsRawValue>> {
         self.run_strict(file_name, false)
     }
     
-    pub fn run_strict(&mut self, file_name: &str, strict: bool) -> JsResult<Root<JsValue>> {
+    pub fn run_strict(&mut self, file_name: &str, strict: bool) -> JsResult<Root<JsRawValue>> {
         let function_ref = try!(self.ir.parse_file(file_name, strict, self.privileged));
         
         let mut ir = String::new();
@@ -154,22 +153,22 @@ impl JsEnv {
         
         let _scope = self.new_local_scope();
         
-        let global = self.handle(JsHandle::Global).as_value(self);
+        let global = self.handle(JsHandle::Global).as_value();
         let global_scope = self.global_scope.as_local(self);
         
         self.run_program(function_ref, global, global_scope)
     }
     
-    pub fn eval(&mut self, js: &str) -> JsResult<Root<JsValue>> {
+    pub fn eval(&mut self, js: &str) -> JsResult<Root<JsRawValue>> {
         let _scope = self.new_local_scope();
         
-        let global = self.handle(JsHandle::Global).as_value(self);
+        let global = self.handle(JsHandle::Global).as_value();
         let global_scope = self.global_scope.as_local(self);
         
         self.eval_scoped(js, false, global, global_scope, ParseMode::Normal)
     }
     
-    fn eval_scoped(&mut self, js: &str, strict: bool, this: Local<JsValue>, scope: Local<JsScope>, mode: ParseMode) -> JsResult<Root<JsValue>> {
+    fn eval_scoped(&mut self, js: &str, strict: bool, this: JsValue, scope: Local<JsScope>, mode: ParseMode) -> JsResult<Root<JsRawValue>> {
         let function_ref = try!(self.ir.parse_string(js, strict, mode, self.privileged));
         
         let mut ir = String::new();
@@ -179,19 +178,19 @@ impl JsEnv {
         self.run_program(function_ref, this, scope)
     }
     
-    fn run_program(&mut self, function_ref: FunctionRef, this: Local<JsValue>, scope: Local<JsScope>) -> JsResult<Root<JsValue>> {
+    fn run_program(&mut self, function_ref: FunctionRef, this: JsValue, scope: Local<JsScope>) -> JsResult<Root<JsRawValue>> {
         let function = self.ir.get_function(function_ref);
         
         let this = if !function.strict && this.is_undefined() {
-            self.handle(JsHandle::Global).as_value(self)
+            self.handle(JsHandle::Global).as_value()
         } else {
             this
         };
         
         let function = try!(self.new_function(function_ref, Some(scope), false));
         
-        let mut result = self.heap.alloc_root::<JsValue>(GC_VALUE);
-        *result = *try!(function.call(self, this, Vec::new(), false));
+        let mut result = self.heap.alloc_root::<JsRawValue>(GC_VALUE);
+        *result = try!(function.call(self, this, Vec::new(), false)).as_raw();
         
         Ok(result)
     }
@@ -200,7 +199,7 @@ impl JsEnv {
         self.ir.interner().intern(name)
     }
     
-    pub fn intern_value(&mut self, value: Local<JsValue>) -> JsResult<Name> {
+    pub fn intern_value(&mut self, value: JsValue) -> JsResult<Name> {
         if value.ty() == JsType::Number {
             let index = value.unwrap_number();
             if index >= 0.0 && index <= i32::MAX as f64 && index as i32 as f64 == index {
@@ -212,11 +211,11 @@ impl JsEnv {
         Ok(self.intern(&index.to_string()))
     }
     
-    fn new_native_function<'a>(&mut self, name: Option<Name>, args: u32, function: JsFn) -> Local<JsValue> {
-        let mut result = JsObject::new_function(self, JsFunction::Native(name, args, function, true), false).as_value(self);
+    fn new_native_function<'a>(&mut self, name: Option<Name>, args: u32, function: JsFn) -> JsValue {
+        let mut result = JsObject::new_function(self, JsFunction::Native(name, args, function, true), false).as_value();
         
         let mut proto = self.create_object();
-        let value = proto.as_value(self);
+        let value = proto.as_value();
         result.define_own_property(self, name::PROTOTYPE, JsDescriptor::new_value(value, false, false, false), false).ok();
         proto.define_own_property(self, name::CONSTRUCTOR, JsDescriptor::new_value(result, true, false, true), false).ok();
         
@@ -237,7 +236,7 @@ pub enum JsPreferredType {
 
 #[allow(unused_variables)]
 pub trait JsItem {
-    fn as_value(&self, env: &JsEnv) -> Local<JsValue>;
+    fn as_value(&self) -> JsValue;
     
     fn get_own_property(&self, env: &JsEnv, property: Name) -> Option<JsDescriptor> {
         None
@@ -257,22 +256,22 @@ pub trait JsItem {
     }
     
     // 8.12.3 [[Get]] (P)
-    fn get(&self, env: &mut JsEnv, property: Name) -> JsResult<Local<JsValue>> {
+    fn get(&self, env: &mut JsEnv, property: Name) -> JsResult<JsValue> {
         if let Some(desc) = self.get_property(env, property) {
             return if desc.is_data() {
-                Ok(desc.value(env))
+                Ok(desc.value())
             } else {
-                let get = desc.get(env);
+                let get = desc.get();
                 if get.is_undefined() {
-                    Ok(env.new_undefined())
+                    Ok(JsValue::new_undefined())
                 } else {
-                    let this = self.as_value(env);
+                    let this = self.as_value();
                     get.call(env, this, Vec::new(), false)
                 }
             }
         }
 
-        Ok(env.new_undefined())
+        Ok(JsValue::new_undefined())
     }
     
     // 8.12.4 [[CanPut]] (P)
@@ -298,7 +297,7 @@ pub trait JsItem {
                         false
                     }
                 } else {
-                    if !self.is_extensible(env) {
+                    if !self.is_extensible() {
                         false
                     } else {
                         inherited.is_writable()
@@ -307,11 +306,11 @@ pub trait JsItem {
             }
         }
 
-        self.is_extensible(env)
+        self.is_extensible()
     }
     
     // 8.12.5 [[Put]] ( P, V, Throw )
-    fn put(&mut self, env: &mut JsEnv, property: Name, value: Local<JsValue>, throw: bool) -> JsResult<()> {
+    fn put(&mut self, env: &mut JsEnv, property: Name, value: JsValue, throw: bool) -> JsResult<()> {
         if !self.can_put(env, property) {
             return if throw {
                 Err(JsError::new_type(env, ::errors::TYPE_CANNOT_PUT))
@@ -334,8 +333,8 @@ pub trait JsItem {
         
         if let Some(desc) = self.get_property(env, property) {
             if desc.is_accessor() {
-                let this = self.as_value(env);
-                let set = desc.set(env);
+                let this = self.as_value();
+                let set = desc.set();
                 // TODO #71: This is not conform the specs. The specs state that
                 // this cannot be undefined. However nothing is stopping
                 // you from only specifying a getter.
@@ -365,11 +364,11 @@ pub trait JsItem {
     }
     
     // 8.12.8 [[DefaultValue]] (hint)
-    fn default_value(&self, env: &mut JsEnv, hint: JsPreferredType) -> JsResult<Local<JsValue>> {
+    fn default_value(&self, env: &mut JsEnv, hint: JsPreferredType) -> JsResult<JsValue> {
         let hint = if hint == JsPreferredType::None {
-            let date_class = try!(env.handle(JsHandle::Global).as_value(env).get(env, name::DATE_CLASS));
+            let date_class = try!(env.handle(JsHandle::Global).as_value().get(env, name::DATE_CLASS));
             
-            let object = self.as_value(env);
+            let object = self.as_value();
             if try!(date_class.has_instance(env, object)) {
                 JsPreferredType::String
             } else {
@@ -379,9 +378,9 @@ pub trait JsItem {
             hint
         };
         
-        fn try_call(env: &mut JsEnv, this: Local<JsValue>, method: Local<JsValue>) -> JsResult<Option<Local<JsValue>>> {
-            if method.is_callable(env) {
-                let this = this.as_value(env);
+        fn try_call(env: &mut JsEnv, this: JsValue, method: JsValue) -> JsResult<Option<JsValue>> {
+            if method.is_callable() {
+                let this = this.as_value();
                 let val = try!(method.call(env, this, Vec::new(), false));
                 if val.ty().is_primitive() {
                     return Ok(Some(val));
@@ -391,7 +390,7 @@ pub trait JsItem {
             Ok(None)
         }
         
-        let this = self.as_value(env);
+        let this = self.as_value();
         
         if hint == JsPreferredType::String {
             let to_string = try!(this.get(env, name::TO_STRING));
@@ -426,67 +425,65 @@ pub trait JsItem {
         if throw { Err(JsError::new_type(env, ::errors::TYPE_CANNOT_PUT)) } else { Ok(false) }
     }
     
-    fn is_callable(&self, env: &JsEnv) -> bool {
+    fn is_callable(&self) -> bool {
         false
     }
     
-    fn call(&self, env: &mut JsEnv, this: Local<JsValue>, args: Vec<Local<JsValue>>, strict: bool) -> JsResult<Local<JsValue>> {
-        let args = JsArgs::new(env, this, self.as_value(env), &args);
+    fn call(&self, env: &mut JsEnv, this: JsValue, args: Vec<JsValue>, strict: bool) -> JsResult<JsValue> {
+        let args = JsArgs::new(env, this, self.as_value(), &args);
         
         try!(env.call(JsFnMode::new(false, strict), args));
         
-        let mut result = env.new_value();
-        *result = env.stack.pop();
+        let result = env.stack.pop().as_value(env);
         
         Ok(result)
     }
     
-    fn can_construct(&self, env: &JsEnv) -> bool {
+    fn can_construct(&self) -> bool {
         false
     }
     
     // 13.2.2 [[Construct]]
     // 15.3.4.5.2 [[Construct]]
-    fn construct(&self, env: &mut JsEnv, args: Vec<Local<JsValue>>) -> JsResult<Local<JsValue>> {
-        let args = JsArgs::new(env, env.new_undefined(), self.as_value(env), &args);
+    fn construct(&self, env: &mut JsEnv, args: Vec<JsValue>) -> JsResult<JsValue> {
+        let args = JsArgs::new(env, JsValue::new_undefined(), self.as_value(), &args);
         
         try!(env.construct(args));
         
-        let mut result = env.new_value();
-        *result = env.stack.pop();
+        let result = env.stack.pop().as_value(env);
         
         Ok(result)
     }
     
-    fn has_prototype(&self, env: &JsEnv) -> bool {
+    fn has_prototype(&self) -> bool {
         false
     }
     
-    fn prototype(&self, env: &JsEnv) -> Option<Local<JsValue>> {
-        panic!("prototype not supported on {:?}", self.as_value(env).ty());
+    fn prototype(&self, env: &JsEnv) -> Option<JsValue> {
+        panic!("prototype not supported on {:?}", self.as_value().ty());
     }
     
-    fn set_prototype(&mut self, env: &JsEnv, prototype: Option<Local<JsValue>>) {
-        panic!("prototype not supported on {:?}", self.as_value(env).ty());
+    fn set_prototype(&mut self, prototype: Option<JsValue>) {
+        panic!("prototype not supported on {:?}", self.as_value().ty());
     }
     
-    fn has_class(&self, env: &JsEnv) -> bool {
+    fn has_class(&self) -> bool {
         false
     }
     
-    fn class(&self, env: &JsEnv) -> Option<Name> {
+    fn class(&self) -> Option<Name> {
         None
     }
     
-    fn set_class(&mut self, env: &JsEnv, class: Option<Name>) {
+    fn set_class(&mut self, class: Option<Name>) {
         panic!("class not supported");
     }
     
-    fn is_extensible(&self, env: &JsEnv) -> bool {
+    fn is_extensible(&self) -> bool {
         true
     }
     
-    fn has_instance(&self, env: &mut JsEnv, object: Local<JsValue>) -> JsResult<bool> {
+    fn has_instance(&self, env: &mut JsEnv, object: JsValue) -> JsResult<bool> {
         Err(JsError::new_type(env, ::errors::TYPE_CANNOT_HAS_INSTANCE))
     }
     
@@ -494,16 +491,16 @@ pub trait JsItem {
         panic!("scope not supported");
     }
     
-    fn set_scope(&mut self, env: &JsEnv, scope: Option<Local<JsScope>>) {
+    fn set_scope(&mut self, scope: Option<Local<JsScope>>) {
         panic!("scope not supported");
     }
 }
 
 #[derive(Copy, Clone)]
 pub struct JsDescriptor {
-    pub value: Option<Local<JsValue>>,
-    pub get: Option<Local<JsValue>>,
-    pub set: Option<Local<JsValue>>,
+    pub value: Option<JsValue>,
+    pub get: Option<JsValue>,
+    pub set: Option<JsValue>,
     pub writable: Option<bool>,
     pub enumerable: Option<bool>,
     pub configurable: Option<bool>
@@ -521,7 +518,7 @@ impl JsDescriptor {
         }
     }
     
-    pub fn new_value(value: Local<JsValue>, writable: bool, enumerable: bool, configurable: bool) -> JsDescriptor {
+    pub fn new_value(value: JsValue, writable: bool, enumerable: bool, configurable: bool) -> JsDescriptor {
         JsDescriptor {
             value: Some(value),
             get: None,
@@ -532,11 +529,11 @@ impl JsDescriptor {
         }
     }
     
-    pub fn new_simple_value(value: Local<JsValue>) -> JsDescriptor {
+    pub fn new_simple_value(value: JsValue) -> JsDescriptor {
         Self::new_value(value, true, true, true)
     }
     
-    pub fn new_accessor(get: Option<Local<JsValue>>, set: Option<Local<JsValue>>, enumerable: bool, configurable: bool) -> JsDescriptor {
+    pub fn new_accessor(get: Option<JsValue>, set: Option<JsValue>, enumerable: bool, configurable: bool) -> JsDescriptor {
         JsDescriptor {
             value: None,
             get: get,
@@ -547,12 +544,12 @@ impl JsDescriptor {
         }
     }
     
-    pub fn new_simple_accessor(get: Option<Local<JsValue>>, set: Option<Local<JsValue>>) -> JsDescriptor {
+    pub fn new_simple_accessor(get: Option<JsValue>, set: Option<JsValue>) -> JsDescriptor {
         Self::new_accessor(get, set, true, true)
     }
     
     pub fn is_same(&self, env: &JsEnv, other: &JsDescriptor) -> bool {
-        fn is_same(env: &JsEnv, x: &Option<Local<JsValue>>, y: &Option<Local<JsValue>>) -> bool{
+        fn is_same(env: &JsEnv, x: &Option<JsValue>, y: &Option<JsValue>) -> bool{
             (x.is_none() && y.is_none()) || (x.is_some() && y.is_some() && env.same_value(x.unwrap(), y.unwrap()))
         }
         
@@ -579,16 +576,16 @@ impl JsDescriptor {
         !(self.is_accessor() || self.is_data())
     }
     
-    pub fn value(&self, env: &JsEnv) -> Local<JsValue> {
-        self.value.unwrap_or_else(|| env.new_undefined())
+    pub fn value(&self) -> JsValue {
+        self.value.unwrap_or_else(|| JsValue::new_undefined())
     }
     
-    pub fn get(&self, env: &JsEnv) -> Local<JsValue> {
-        self.get.unwrap_or_else(|| env.new_undefined())
+    pub fn get(&self) -> JsValue {
+        self.get.unwrap_or_else(|| JsValue::new_undefined())
     }
     
-    pub fn set(&self, env: &JsEnv) -> Local<JsValue> {
-        self.set.unwrap_or_else(|| env.new_undefined())
+    pub fn set(&self) -> JsValue {
+        self.set.unwrap_or_else(|| JsValue::new_undefined())
     }
     
     pub fn is_writable(&self) -> bool {
@@ -608,34 +605,34 @@ impl JsDescriptor {
     }
     
     // 8.10.4 FromPropertyDescriptor ( Desc )
-    pub fn from_property_descriptor(&self, env: &mut JsEnv) -> JsResult<Local<JsValue>> {
+    pub fn from_property_descriptor(&self, env: &mut JsEnv) -> JsResult<JsValue> {
         let mut obj = env.create_object();
         
         if self.is_data() {
-            let value = self.value(env);
-            let writable = env.new_bool(self.is_writable());
+            let value = self.value();
+            let writable = JsValue::new_bool(self.is_writable());
             
             try!(obj.define_own_property(env, name::VALUE, JsDescriptor::new_simple_value(value), false));
             try!(obj.define_own_property(env, name::WRITABLE, JsDescriptor::new_simple_value(writable), false));
         } else if self.is_accessor() {
-            let get = self.get(env);
-            let set = self.set(env);
+            let get = self.get();
+            let set = self.set();
             
             try!(obj.define_own_property(env, name::GET, JsDescriptor::new_simple_value(get), false));
             try!(obj.define_own_property(env, name::SET, JsDescriptor::new_simple_value(set), false));
         }
         
-        let enumerable = env.new_bool(self.is_enumerable());
-        let configurable = env.new_bool(self.is_configurable());
+        let enumerable = JsValue::new_bool(self.is_enumerable());
+        let configurable = JsValue::new_bool(self.is_configurable());
         
         try!(obj.define_own_property(env, name::ENUMERABLE, JsDescriptor::new_simple_value(enumerable), false));
         try!(obj.define_own_property(env, name::CONFIGURABLE, JsDescriptor::new_simple_value(configurable), false));
         
-        Ok(obj.as_value(env))
+        Ok(obj.as_value())
     }
     
     // 8.10.5 ToPropertyDescriptor ( Obj )
-    pub fn to_property_descriptor(env: &mut JsEnv, obj: Local<JsValue>) -> JsResult<JsDescriptor> {
+    pub fn to_property_descriptor(env: &mut JsEnv, obj: JsValue) -> JsResult<JsDescriptor> {
         if obj.ty() != JsType::Object {
             Err(JsError::new_type(env, ::errors::TYPE_INVALID))
         } else {
@@ -664,7 +661,7 @@ impl JsDescriptor {
             };
             let getter = if obj.has_property(env, name::GET) {
                 let getter = try!(obj.get(env, name::GET));
-                if getter.ty() != JsType::Undefined && !getter.is_callable(env) {
+                if getter.ty() != JsType::Undefined && !getter.is_callable() {
                     return Err(JsError::new_type(env, ::errors::TYPE_ACCESSOR_NOT_CALLABLE));
                 }
                 Some(getter)
@@ -673,7 +670,7 @@ impl JsDescriptor {
             };
             let setter = if obj.has_property(env, name::SET) {
                 let setter = try!(obj.get(env, name::SET));
-                if setter.ty() != JsType::Undefined && !setter.is_callable(env) {
+                if setter.ty() != JsType::Undefined && !setter.is_callable() {
                     return Err(JsError::new_type(env, ::errors::TYPE_ACCESSOR_NOT_CALLABLE));
                 }
                 Some(setter)
@@ -763,16 +760,16 @@ pub struct JsArgs {
 }
 
 impl JsArgs {
-    pub fn new(env: &JsEnv, this: Local<JsValue>, function: Local<JsValue>, args: &[Local<JsValue>]) -> JsArgs {
+    pub fn new(env: &JsEnv, this: JsValue, function: JsValue, args: &[JsValue]) -> JsArgs {
         let stack = &*env.stack;
         
         let frame = stack.create_frame(0);
         
-        stack.push(*this);
-        stack.push(*function);
+        stack.push(this.as_raw());
+        stack.push(function.as_raw());
         
         for arg in args {
-            stack.push(**arg);
+            stack.push(arg.as_raw());
         }
         
         JsArgs {
@@ -781,15 +778,15 @@ impl JsArgs {
         }
     }
     
-    pub fn arg(&self, env: &JsEnv, index: usize) -> Local<JsValue> {
+    pub fn arg(&self, env: &JsEnv, index: usize) -> JsValue {
         if self.argc > index {
             self.frame.get(env, index + 2)
         } else {
-            env.new_undefined()
+            JsValue::new_undefined()
         }
     }
     
-    pub fn arg_or(&self, env: &JsEnv, index: usize, def: Local<JsValue>) -> Local<JsValue> {
+    pub fn arg_or(&self, env: &JsEnv, index: usize, def: JsValue) -> JsValue {
         if self.argc > index {
             self.frame.get(env, index + 2)
         } else {
@@ -797,7 +794,7 @@ impl JsArgs {
         }
     }
     
-    pub fn map_or<U, F: FnOnce(&mut JsEnv, Local<JsValue>) -> U>(&self, env: &mut JsEnv, index: usize, def: U, f: F) -> U {
+    pub fn map_or<U, F: FnOnce(&mut JsEnv, JsValue) -> U>(&self, env: &mut JsEnv, index: usize, def: U, f: F) -> U {
         if self.argc > index {
             let value = self.frame.get(env, index + 2);
             f(env, value)
@@ -806,7 +803,7 @@ impl JsArgs {
         }
     }
     
-    pub fn map_or_else<U, D: FnOnce(&mut JsEnv) -> U, F: FnOnce(&mut JsEnv, Local<JsValue>) -> U>(&self, env: &mut JsEnv, index: usize, def: D, f: F) -> U {
+    pub fn map_or_else<U, D: FnOnce(&mut JsEnv) -> U, F: FnOnce(&mut JsEnv, JsValue) -> U>(&self, env: &mut JsEnv, index: usize, def: D, f: F) -> U {
         if self.argc > index {
             let value = self.frame.get(env, index + 2);
             f(env, value)
@@ -815,7 +812,7 @@ impl JsArgs {
         }
     }
     
-    pub fn args(&self, env: &JsEnv) -> Vec<Local<JsValue>> {
+    pub fn args(&self, env: &JsEnv) -> Vec<JsValue> {
         let mut args = Vec::new();
         
         for i in 0..self.argc {
@@ -825,24 +822,24 @@ impl JsArgs {
         args
     }
     
-    pub fn this(&self, env: &JsEnv) -> Local<JsValue> {
+    pub fn this(&self, env: &JsEnv) -> JsValue {
         self.frame.get(env, 0)
     }
     
-    fn set_this(&self, value: JsValue) {
+    fn set_this(&self, value: JsRawValue) {
         self.frame.set(0, value);
     }
     
-    fn raw_this(&self) -> JsValue {
+    fn raw_this(&self) -> JsRawValue {
         self.frame.raw_get(0)
     }
     
-    pub fn function(&self, env: &JsEnv) -> Local<JsValue> {
+    pub fn function(&self, env: &JsEnv) -> JsValue {
         self.frame.get(env, 1)
     }
 }
 
-pub type JsFn = fn(&mut JsEnv, JsFnMode, JsArgs) -> JsResult<Local<JsValue>>;
+pub type JsFn = fn(&mut JsEnv, JsFnMode, JsArgs) -> JsResult<JsValue>;
 
 pub enum JsFunction {
     Ir(FunctionRef),
@@ -857,11 +854,11 @@ pub enum JsError {
     Lex(String),
     Parse(String),
     Reference(String),
-    Runtime(Root<JsValue>)
+    Runtime(Root<JsRawValue>)
 }
 
 impl JsError {
-    fn new_error(env: &mut JsEnv, handle: JsHandle, message: Option<&str>, file_name: Option<&str>, line_number: Option<usize>) -> JsResult<Root<JsValue>> {
+    fn new_error(env: &mut JsEnv, handle: JsHandle, message: Option<&str>, file_name: Option<&str>, line_number: Option<usize>) -> JsResult<Root<JsRawValue>> {
         // If construction of the error fails, we simply propagate the error itself.
         
         let _scope = env.new_local_scope();
@@ -871,21 +868,22 @@ impl JsError {
         let mut args = Vec::new();
         
         args.push(match message {
-            Some(message) => JsString::from_str(env, message).as_value(env),
-            None => env.new_undefined()
+            Some(message) => JsString::from_str(env, message).as_value(),
+            None => JsValue::new_undefined()
         });
         args.push(match file_name {
-            Some(file_name) => JsString::from_str(env, file_name).as_value(env),
-            None => env.new_undefined()
+            Some(file_name) => JsString::from_str(env, file_name).as_value(),
+            None => JsValue::new_undefined()
         });
         args.push(match line_number {
-            Some(line_number) => env.new_number(line_number as f64),
-            None => env.new_undefined()
+            Some(line_number) => JsValue::new_number(line_number as f64),
+            None => JsValue::new_undefined()
         });
         
-        let obj = try!(class.construct(env, args));
+        let mut result = env.heap.alloc_root::<JsRawValue>(GC_VALUE);
+        *result = try!(class.construct(env, args)).as_raw();
         
-        Ok(obj.as_root(env))
+        Ok(result)
     }
     
     pub fn new_runtime(env: &mut JsEnv, handle: JsHandle, message: Option<&str>, file_name: Option<&str>, line_number: Option<usize>) -> JsError {
@@ -915,7 +913,7 @@ impl JsError {
         Self::new_runtime(env, JsHandle::SyntaxError, Some(message), None, None)
     }
     
-    pub fn as_runtime(&self, env: &mut JsEnv) -> Root<JsValue> {
+    pub fn as_runtime(&self, env: &mut JsEnv) -> Root<JsRawValue> {
         match *self {
             JsError::Lex(ref message) | JsError::Parse(ref message) => {
                 match Self::new_error(env, JsHandle::SyntaxError, Some(&message), None, None) {
@@ -932,8 +930,10 @@ impl JsError {
             JsError::Runtime(ref error) => error.clone(),
             ref error @ _ => {
                 // TODO #73: This could be nicer.
-                let error = JsString::from_str(env, &format!("{:?}", error)).as_value(env);
-                error.as_root(env)
+                let mut result = env.heap.alloc_root::<JsRawValue>(GC_VALUE);
+                *result = JsString::from_str(env, &format!("{:?}", error)).as_value().as_raw();
+                
+                result
             }
         }
     }

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -850,41 +850,6 @@ pub enum JsFunction {
     Bound
 }
 
-impl Clone for JsFunction {
-    fn clone(&self) -> JsFunction {
-        match *self {
-            JsFunction::Ir(function_ref) => JsFunction::Ir(function_ref),
-            JsFunction::Native(name, args, callback, can_construct) => JsFunction::Native(name, args, callback, can_construct),
-            JsFunction::Bound => JsFunction::Bound
-        }
-    }
-}
-
-impl PartialEq for JsFunction {
-    fn eq(&self, other: &JsFunction) -> bool {
-        match *self {
-            JsFunction::Ir(function_ref) => {
-                if let JsFunction::Ir(other_function_ref) = *other {
-                    function_ref == other_function_ref
-                } else {
-                    false
-                }
-            }
-            JsFunction::Native(..) => {
-                // TODO #72: Unable to compare pointer types (results in an ICE).
-                false
-            }
-            JsFunction::Bound => {
-                if let JsFunction::Bound = *other {
-                    true
-                } else {
-                    false
-                }
-            }
-        }
-    }
-}
-
 pub type JsResult<T> = Result<T, JsError>;
 
 pub enum JsError {

--- a/src/rt/null.rs
+++ b/src/rt/null.rs
@@ -1,20 +1,19 @@
 use rt::{JsItem, JsEnv, JsValue, JsDescriptor};
-use gc::Local;
 use ::{JsResult, JsError};
 use syntax::Name;
 
 pub struct JsNull;
 
 impl JsItem for JsNull {
-    fn as_value(&self, env: &JsEnv) -> Local<JsValue> {
-        env.new_null()
+    fn as_value(&self) -> JsValue {
+        JsValue::new_null()
     }
     
     fn get_property(&self, _: &JsEnv, _: Name) -> Option<JsDescriptor> {
         None
     }
     
-    fn get(&self, env: &mut JsEnv, _: Name) -> JsResult<Local<JsValue>> {
+    fn get(&self, env: &mut JsEnv, _: Name) -> JsResult<JsValue> {
         Err(JsError::new_type(env, ::errors::TYPE_NULL))
     }
     
@@ -22,7 +21,7 @@ impl JsItem for JsNull {
         panic!("not supported");
     }
     
-    fn put(&mut self, env: &mut JsEnv, _: Name, _: Local<JsValue>, _: bool) -> JsResult<()> {
+    fn put(&mut self, env: &mut JsEnv, _: Name, _: JsValue, _: bool) -> JsResult<()> {
         Err(JsError::new_type(env, ::errors::TYPE_NULL))
     }
     

--- a/src/rt/number.rs
+++ b/src/rt/number.rs
@@ -1,5 +1,4 @@
 use rt::{JsItem, JsEnv, JsValue, JsHandle};
-use gc::Local;
 
 pub struct JsNumber {
     value: f64
@@ -14,15 +13,15 @@ impl JsNumber {
 }
 
 impl JsItem for JsNumber {
-    fn as_value(&self, env: &JsEnv) -> Local<JsValue> {
-        env.new_number(self.value)
+    fn as_value(&self) -> JsValue {
+        JsValue::new_number(self.value)
     }
     
-    fn has_prototype(&self, _: &JsEnv) -> bool {
+    fn has_prototype(&self) -> bool {
         true
     }
     
-    fn prototype(&self, env: &JsEnv) -> Option<Local<JsValue>> {
-        Some(env.handle(JsHandle::Number).as_value(env))
+    fn prototype(&self, env: &JsEnv) -> Option<JsValue> {
+        Some(env.handle(JsHandle::Number).as_value())
     }
 }

--- a/src/rt/object/array_store.rs
+++ b/src/rt/object/array_store.rs
@@ -8,6 +8,7 @@ use std::mem::{transmute, zeroed, size_of};
 use rt::object::sparse_array::SparseArray;
 
 // Modifications to this struct must be synchronized with the GC walker.
+#[repr(C)]
 pub struct ArrayStore {
     array: Ptr<SparseArray>,
     props: Ptr<HashStore>

--- a/src/rt/object/array_store.rs
+++ b/src/rt/object/array_store.rs
@@ -4,7 +4,7 @@ use rt::object::{Store, StoreKey, Entry};
 use rt::object::hash_store::HashStore;
 use syntax::Name;
 use gc::{Local, GcWalker, GcAllocator, AsPtr, Ptr, ptr_t};
-use std::mem::{transmute, zeroed};
+use std::mem::{transmute, zeroed, size_of};
 use rt::object::sparse_array::SparseArray;
 
 // Modifications to this struct must be synchronized with the GC walker.
@@ -126,4 +126,6 @@ pub unsafe fn validate_walker_for_array_store(walker: &GcWalker) {
     object.props = Ptr::from_ptr(transmute(1usize));
     validate_walker_field(walker, GC_ARRAY_STORE, ptr, true);
     object.props = Ptr::null();
+    
+    assert_eq!(size_of::<ArrayStore>(), 16);
 }

--- a/src/rt/object/hash_store.rs
+++ b/src/rt/object/hash_store.rs
@@ -8,6 +8,7 @@ use gc::{Local, Array, GcWalker, ptr_t};
 use std::mem::{transmute, zeroed, size_of};
 
 // Modifications to this struct must be synchronized with the GC walker.
+#[repr(C)]
 pub struct HashStore {
     entries: Array<Entry>,
     count: u32

--- a/src/rt/object/hash_store.rs
+++ b/src/rt/object/hash_store.rs
@@ -5,7 +5,7 @@ use rt::validate_walker_field;
 use rt::object::{Store, StoreKey, Entry};
 use syntax::Name;
 use gc::{Local, Array, GcWalker, ptr_t};
-use std::mem::{transmute, zeroed};
+use std::mem::{transmute, zeroed, size_of};
 
 // Modifications to this struct must be synchronized with the GC walker.
 pub struct HashStore {
@@ -332,6 +332,8 @@ pub unsafe fn validate_walker_for_hash_store(walker: &GcWalker) {
     object.count = 1;
     validate_walker_field(walker, GC_HASH_STORE, ptr, false);
     object.count = 0;
+    
+    assert_eq!(size_of::<HashStore>(), 16);
 }
 
 /*

--- a/src/rt/object/hash_store.rs
+++ b/src/rt/object/hash_store.rs
@@ -341,7 +341,7 @@ pub unsafe fn validate_walker_for_hash_store(walker: &GcWalker) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rt::{JsType, JsValue, JsRawValue};
+    use rt::{JsType, JsRawValue, Data};
     use gc::*;
     use syntax::ast::Name;
     
@@ -370,11 +370,11 @@ mod tests {
         let ctx = create_context();
         let mut hash = Hash::new(&ctx.heap, ctx.type_id, 7);
         
-        hash.add(A, JsValue::new_number(1.0));
+        hash.add(A, JsRawValue::new_number(1.0));
         
         assert_eq!(1, hash.count);
         assert!(hash.get_value(A).is_some());
-        assert_eq!(JsValue::new_number(1.0), hash.get_value(A).unwrap());
+        assert_eq!(JsRawValue::new_number(1.0), hash.get_value(A).unwrap());
     }
     
     #[test]
@@ -382,14 +382,14 @@ mod tests {
         let ctx = create_context();
         let mut hash = Hash::new(&ctx.heap, ctx.type_id, 7);
         
-        hash.add(A, JsValue::new_number(1.0));
-        hash.add(A1, JsValue::new_number(2.0));
+        hash.add(A, JsRawValue::new_number(1.0));
+        hash.add(A1, JsRawValue::new_number(2.0));
         
         assert_eq!(2, hash.count);
         assert!(hash.get_value(A).is_some());
-        assert_eq!(JsValue::new_number(1.0), hash.get_value(A).unwrap());
+        assert_eq!(JsRawValue::new_number(1.0), hash.get_value(A).unwrap());
         assert!(hash.get_value(A1).is_some());
-        assert_eq!(JsValue::new_number(2.0), hash.get_value(A1).unwrap());
+        assert_eq!(JsRawValue::new_number(2.0), hash.get_value(A1).unwrap());
     }
     
     #[test]
@@ -398,7 +398,7 @@ mod tests {
         let mut hash = Hash::new(&ctx.heap, ctx.type_id, 7);
         
         for i in 0..8 {
-            hash.add(Name(i), JsValue::new_number(i as f64));
+            hash.add(Name(i), JsRawValue::new_number(i as f64));
             dump_hash(&hash);
         }
         
@@ -408,7 +408,7 @@ mod tests {
         for i in 0..8 {
             let value = hash.get_value(Name(i));
             assert!(value.is_some());
-            assert_eq!(JsValue::new_number(i as f64), value.unwrap());
+            assert_eq!(JsRawValue::new_number(i as f64), value.unwrap());
         }
     }
     
@@ -417,14 +417,14 @@ mod tests {
         let ctx = create_context();
         let mut hash = Hash::new(&ctx.heap, ctx.type_id, 7);
         
-        hash.add(A, JsValue::new_number(1.0));
-        hash.add(A1, JsValue::new_number(2.0));
+        hash.add(A, JsRawValue::new_number(1.0));
+        hash.add(A1, JsRawValue::new_number(2.0));
         
         assert_eq!(2, hash.count);
         assert!(hash.get_value(A).is_some());
-        assert_eq!(JsValue::new_number(1.0), hash.get_value(A).unwrap());
+        assert_eq!(JsRawValue::new_number(1.0), hash.get_value(A).unwrap());
         assert!(hash.get_value(A1).is_some());
-        assert_eq!(JsValue::new_number(2.0), hash.get_value(A1).unwrap());
+        assert_eq!(JsRawValue::new_number(2.0), hash.get_value(A1).unwrap());
         
         let removed = hash.remove(A);
         assert!(removed);
@@ -435,7 +435,7 @@ mod tests {
         assert_eq!(1, hash.count);
         assert!(!hash.get_value(A).is_some());
         assert!(hash.get_value(A1).is_some());
-        assert_eq!(JsValue::new_number(2.0), hash.get_value(A1).unwrap());
+        assert_eq!(JsRawValue::new_number(2.0), hash.get_value(A1).unwrap());
     }
     
     #[test]
@@ -443,17 +443,17 @@ mod tests {
         let ctx = create_context();
         let mut hash = Hash::new(&ctx.heap, ctx.type_id, 7);
         
-        hash.add(A, JsValue::new_number(1.0));
-        hash.add(A1, JsValue::new_number(2.0));
-        hash.add(A2, JsValue::new_number(3.0));
+        hash.add(A, JsRawValue::new_number(1.0));
+        hash.add(A1, JsRawValue::new_number(2.0));
+        hash.add(A2, JsRawValue::new_number(3.0));
         
         assert_eq!(3, hash.count);
         assert!(hash.get_value(A).is_some());
-        assert_eq!(JsValue::new_number(1.0), hash.get_value(A).unwrap());
+        assert_eq!(JsRawValue::new_number(1.0), hash.get_value(A).unwrap());
         assert!(hash.get_value(A1).is_some());
-        assert_eq!(JsValue::new_number(2.0), hash.get_value(A1).unwrap());
+        assert_eq!(JsRawValue::new_number(2.0), hash.get_value(A1).unwrap());
         assert!(hash.get_value(A2).is_some());
-        assert_eq!(JsValue::new_number(3.0), hash.get_value(A2).unwrap());
+        assert_eq!(JsRawValue::new_number(3.0), hash.get_value(A2).unwrap());
         
         let removed = hash.remove(A1);
         assert!(removed);
@@ -463,10 +463,10 @@ mod tests {
         
         assert_eq!(2, hash.count);
         assert!(hash.get_value(A).is_some());
-        assert_eq!(JsValue::new_number(1.0), hash.get_value(A).unwrap());
+        assert_eq!(JsRawValue::new_number(1.0), hash.get_value(A).unwrap());
         assert!(!hash.get_value(A1).is_some());
         assert!(hash.get_value(A2).is_some());
-        assert_eq!(JsValue::new_number(3.0), hash.get_value(A2).unwrap());
+        assert_eq!(JsRawValue::new_number(3.0), hash.get_value(A2).unwrap());
     }
     
     #[test]
@@ -475,7 +475,7 @@ mod tests {
         let mut hash = Hash::new(&ctx.heap, ctx.type_id, 7);
         
         for i in 0..8 {
-            hash.add(Name(i), JsValue::new_number(i as f64));
+            hash.add(Name(i), JsRawValue::new_number(i as f64));
             dump_hash(&hash);
         }
         

--- a/src/rt/object/mod.rs
+++ b/src/rt/object/mod.rs
@@ -9,9 +9,8 @@ use gc::{Local, Ptr, AsPtr, ptr_t, GcWalker};
 use ::{JsResult, JsError};
 use self::hash_store::HashStore;
 use self::array_store::ArrayStore;
-use std::mem;
 use std::str::FromStr;
-use std::mem::{transmute, zeroed};
+use std::mem::{zeroed, transmute, size_of};
 
 mod hash_store;
 mod array_store;
@@ -680,7 +679,7 @@ pub struct Entry {
 
 impl Entry {
     fn empty() -> Entry {
-        unsafe { mem::zeroed() }
+        unsafe { zeroed() }
     }
     
     fn is_valid(&self) -> bool {
@@ -820,6 +819,8 @@ unsafe fn validate_walker_for_object(walker: &GcWalker) {
     object.extensible = true;
     validate_walker_field(walker, GC_OBJECT, ptr, false);
     object.extensible = false;
+    
+    assert_eq!(size_of::<JsObject>(), 136);
 }
 
 unsafe fn validate_walker_for_entry(walker: &GcWalker) {
@@ -849,4 +850,6 @@ unsafe fn validate_walker_for_entry(walker: &GcWalker) {
     object.value2 = transmute(zeroed::<JsValue>());
     
     validate_walker_for_embedded_value(walker, ptr, GC_ENTRY, value_offset, &mut object.value2);
+    
+    assert_eq!(size_of::<Entry>(), 48);
 }

--- a/src/rt/object/mod.rs
+++ b/src/rt/object/mod.rs
@@ -17,6 +17,7 @@ mod array_store;
 mod sparse_array;
 
 // Modifications to this struct must be synchronized with the GC walker.
+#[repr(C)]
 pub struct JsObject {
     class: Option<Name>,
     value: JsValue,
@@ -667,8 +668,9 @@ const ENUMERABLE   : u32 = 0b00100;
 const CONFIGURABLE : u32 = 0b01000;
 const ACCESSOR     : u32 = 0b10000;
 
-#[derive(Copy, Clone)]
 // Modifications to this struct must be synchronized with the GC walker.
+#[derive(Copy, Clone)]
+#[repr(C)]
 pub struct Entry {
     name: Name,
     flags: u32,

--- a/src/rt/object/mod.rs
+++ b/src/rt/object/mod.rs
@@ -94,7 +94,7 @@ impl JsObject {
         result.define_own_property(env, name::NAME, JsDescriptor::new_value(name, false, false, true), false).ok();
         
         if strict {
-            let thrower = env.new_native_function(None, 0, &throw_type_error);
+            let thrower = env.new_native_function(None, 0, throw_type_error);
             
             result.define_own_property(env, name::CALLER, JsDescriptor::new_accessor(Some(thrower), Some(thrower), false, false), false).ok();
             result.define_own_property(env, name::ARGUMENTS, JsDescriptor::new_accessor(Some(thrower), Some(thrower), false, false), false).ok();
@@ -820,7 +820,7 @@ unsafe fn validate_walker_for_object(walker: &GcWalker) {
     validate_walker_field(walker, GC_OBJECT, ptr, false);
     object.extensible = false;
     
-    assert_eq!(size_of::<JsObject>(), 136);
+    assert_eq!(size_of::<JsObject>(), 128);
 }
 
 unsafe fn validate_walker_for_entry(walker: &GcWalker) {

--- a/src/rt/object/sparse_array.rs
+++ b/src/rt/object/sparse_array.rs
@@ -13,6 +13,7 @@ const INITIAL_CHUNK_COUNT : usize = 10;
 const MAX_ARRAY_SIZE : usize = 1024;
 const MAX_ARRAY_SIZE_FILL_FACTOR : f64 = 0.5;
 
+#[repr(C)]
 pub struct SparseArray {
     items: Array<Entry>,
     chunks: Array<Chunk>,
@@ -21,6 +22,7 @@ pub struct SparseArray {
 }
 
 #[derive(Copy, Clone)]
+#[repr(C)]
 struct Chunk {
     offset: usize,
     items: Array<Entry>

--- a/src/rt/object/sparse_array.rs
+++ b/src/rt/object/sparse_array.rs
@@ -4,7 +4,7 @@ use rt::object::{StoreKey, Entry};
 use std::cmp::{min, max};
 use rt::{GC_ENTRY, GC_ARRAY_CHUNK, GC_SPARSE_ARRAY, validate_walker_field};
 use syntax::Name;
-use std::mem::{transmute, zeroed};
+use std::mem::{transmute, zeroed, size_of};
 
 const CHUNK_SHIFT : usize = 5;
 const CHUNK_SIZE : usize = 1 << CHUNK_SHIFT;
@@ -313,6 +313,8 @@ unsafe fn validate_walker_for_sparse_array(walker: &GcWalker) {
     object.used = 1;
     validate_walker_field(walker, GC_SPARSE_ARRAY, ptr, false);
     object.used = 0;
+    
+    assert_eq!(size_of::<SparseArray>(), 32);
 }
 
 unsafe fn validate_walker_for_array_chunk(walker: &GcWalker) {
@@ -326,4 +328,6 @@ unsafe fn validate_walker_for_array_chunk(walker: &GcWalker) {
     object.items = Array::from_ptr(transmute(1usize));
     validate_walker_field(walker, GC_ARRAY_CHUNK, ptr, true);
     object.items = Array::null();
+    
+    assert_eq!(size_of::<Chunk>(), 16);
 }

--- a/src/rt/regexp.rs
+++ b/src/rt/regexp.rs
@@ -9,6 +9,7 @@ use ::{JsResult, JsError};
 use std::mem::{transmute, zeroed, size_of};
 
 // Modifications to this struct must be synchronized with the GC walker.
+#[repr(C)]
 pub struct JsRegExp {
     pattern: Ptr<JsString>,
     flags: Ptr<JsString>,

--- a/src/rt/regexp.rs
+++ b/src/rt/regexp.rs
@@ -167,8 +167,8 @@ impl JsRegExp {
 }
 
 impl Local<JsRegExp> {
-    pub fn as_value(&self, env: &JsEnv) -> Local<JsValue> {
-        env.new_regexp(*self)
+    pub fn as_value(&self) -> JsValue {
+        JsValue::new_regexp(*self)
     }
     
     pub fn regex<'a>(&'a self) -> &'a Regex {

--- a/src/rt/regexp.rs
+++ b/src/rt/regexp.rs
@@ -6,7 +6,7 @@ use gc::*;
 use self::regex::Regex;
 use util::manualbox::ManualBox;
 use ::{JsResult, JsError};
-use std::mem::{transmute, zeroed};
+use std::mem::{transmute, zeroed, size_of};
 
 // Modifications to this struct must be synchronized with the GC walker.
 pub struct JsRegExp {
@@ -222,4 +222,6 @@ pub unsafe fn validate_walker(walker: &GcWalker) {
     object.multiline = true;
     validate_walker_field(walker, GC_REGEXP, ptr, false);
     object.multiline = false;
+    
+    assert_eq!(size_of::<JsRegExp>(), 32);
 }

--- a/src/rt/runtime.rs
+++ b/src/rt/runtime.rs
@@ -149,7 +149,7 @@ impl JsEnv {
             JsFunction::Native(_, _, ref callback, _) => {
                 let frame = args.frame;
                 
-                let result = try!(callback.call(self, mode, args));
+                let result = try!(callback(self, mode, args));
                 
                 self.stack.drop_frame(frame);
                 self.stack.push(*result);
@@ -579,7 +579,7 @@ impl JsEnv {
             let function = args.function(self);
             try!(result.define_own_property(self, name::CALLEE, JsDescriptor::new_value(function, true, false, true), false));
         } else {
-            let thrower = self.new_native_function(None, 0, &throw_type_error);
+            let thrower = self.new_native_function(None, 0, throw_type_error);
             
             try!(result.define_own_property(self, name::CALLEE, JsDescriptor::new_accessor(Some(thrower), Some(thrower), false, false), false));
             try!(result.define_own_property(self, name::CALLER, JsDescriptor::new_accessor(Some(thrower), Some(thrower), false, false), false));

--- a/src/rt/runtime.rs
+++ b/src/rt/runtime.rs
@@ -35,7 +35,7 @@ pub enum ComparisonResult {
 
 impl JsEnv {
     // http://ecma-international.org/ecma-262/5.1/#sec-11.6.1
-    pub fn add(&mut self, lhs: Local<JsValue>, rhs: Local<JsValue>) -> JsResult<Local<JsValue>> {
+    pub fn add(&mut self, lhs: JsValue, rhs: JsValue) -> JsResult<JsValue> {
         let lprim = try!(lhs.to_primitive(self, JsPreferredType::None));
         let rprim = try!(rhs.to_primitive(self, JsPreferredType::None));
         
@@ -44,16 +44,16 @@ impl JsEnv {
             let rhs = try!(rprim.to_string(self));
             let result = JsString::concat(self, &[lhs, rhs]);
             
-            Ok(self.new_string(result))
+            Ok(result.as_value())
         } else {
             let lnum = try!(lprim.to_number(self));
             let rnum = try!(rprim.to_number(self));
-            Ok(self.new_number(lnum + rnum))
+            Ok(JsValue::new_number(lnum + rnum))
         }
     }
     
     // 11.6.2 The Subtraction Operator ( - )
-    pub fn subtract(&mut self, lhs: Local<JsValue>, rhs: Local<JsValue>) -> JsResult<f64> {
+    pub fn subtract(&mut self, lhs: JsValue, rhs: JsValue) -> JsResult<f64> {
         let lnum = try!(lhs.to_number(self));
         let rnum = try!(rhs.to_number(self));
         
@@ -61,7 +61,7 @@ impl JsEnv {
     }
     
     // 11.4.7 Unary - Operator
-    pub fn negative(&mut self, expr: Local<JsValue>) -> JsResult<f64> {
+    pub fn negative(&mut self, expr: JsValue) -> JsResult<f64> {
         let old_value = try!(expr.to_number(self));
         let result = if old_value.is_nan() {
             old_value
@@ -73,7 +73,7 @@ impl JsEnv {
     }
     
     // 11.4.6 Unary + Operator
-    pub fn positive(&mut self, expr: Local<JsValue>) -> JsResult<f64> {
+    pub fn positive(&mut self, expr: JsValue) -> JsResult<f64> {
         expr.to_number(self)
     }
     
@@ -86,11 +86,11 @@ impl JsEnv {
             return Err(JsError::new_type(self, ::errors::TYPE_NOT_A_FUNCTION));
         };
         
-        if mode.construct() && !function_obj.can_construct(self) {
+        if mode.construct() && !function_obj.can_construct() {
             return Err(JsError::new_type(self, ::errors::TYPE_NOT_A_CONSTRUCTOR));
         }
         
-        let function = match function_obj.unwrap_object(self).function() {
+        let function = match function_obj.unwrap_object().function() {
             Some(function) => function,
             None => return Err(JsError::new_type(self, ::errors::TYPE_NOT_A_FUNCTION))
         };
@@ -109,7 +109,7 @@ impl JsEnv {
         result
     }
     
-    fn do_call(&mut self, mode: JsFnMode, args: JsArgs, function_obj: Local<JsValue>, function: &JsFunction) -> JsResult<()> {
+    fn do_call(&mut self, mode: JsFnMode, args: JsArgs, function_obj: JsValue, function: &JsFunction) -> JsResult<()> {
         match *function {
             JsFunction::Ir(function_ref) => {
                 let block = try!(self.ir.get_function_ir(function_ref));
@@ -128,12 +128,12 @@ impl JsEnv {
                     let this = args.this(self);
                     
                     let this = if this.is_null_or_undefined() {
-                        self.handle(JsHandle::Global).as_value(self)
+                        self.handle(JsHandle::Global).as_value()
                     } else {
                         try!(this.to_object(self))
                     };
                     
-                    args.set_this(*this);
+                    args.set_this(this.as_raw());
                 }
                 
                 let scope = function_obj.scope(self)
@@ -151,7 +151,7 @@ impl JsEnv {
                 let result = try!(callback(self, mode, args));
                 
                 self.stack.drop_frame(frame);
-                self.stack.push(*result);
+                self.stack.push(result.as_raw());
                 
                 Ok(())
             }
@@ -182,8 +182,8 @@ impl JsEnv {
     pub fn construct(&mut self, args: JsArgs) -> JsResult<()> {
         let function = args.function(self);
         
-        let is_bound = if function.class(self) == Some(name::FUNCTION_CLASS) {
-            let object = function.as_value(self).unwrap_object(self);
+        let is_bound = if function.class() == Some(name::FUNCTION_CLASS) {
+            let object = function.as_value().unwrap_object();
             match object.function().unwrap() {
                 JsFunction::Bound => true,
                 _ => false
@@ -215,7 +215,7 @@ impl JsEnv {
             
             return match result {
                 Ok(result) => {
-                    self.stack.push(*result);
+                    self.stack.push(result.as_raw());
                     Ok(())
                 }
                 Err(error) => Err(error)
@@ -223,45 +223,45 @@ impl JsEnv {
         }
         
         let mut obj = JsObject::new_local(self, JsStoreType::Hash);
-        obj.set_class(self, Some(name::OBJECT_CLASS));
+        obj.set_class(Some(name::OBJECT_CLASS));
         
         let proto = try!(function.get(self, name::PROTOTYPE));
         if proto.ty() == JsType::Object {
-            obj.set_prototype(self, Some(proto));
+            obj.set_prototype(Some(proto));
         } else {
-            let proto = self.handle(JsHandle::Object).as_value(self);
-            obj.set_prototype(self, Some(proto));
+            let proto = self.handle(JsHandle::Object).as_value();
+            obj.set_prototype(Some(proto));
         }
         
-        let obj = obj.as_value(self);
+        let obj = obj.as_value();
         
-        args.set_this(*obj);
+        args.set_this(obj.as_raw());
         
         try!(self.call(JsFnMode::new(true, false), args));
         
         let frame = self.stack.create_frame(1);
         if frame.raw_get(0).ty() != JsType::Object {
-            frame.set(0, *obj);
+            frame.set(0, obj.as_raw());
         }
         
         Ok(())
     }
     
     // http://ecma-international.org/ecma-262/5.1/#sec-11.4.3
-    pub fn type_of(&mut self, value: Local<JsValue>) -> Local<JsString> {
+    pub fn type_of(&mut self, value: JsValue) -> Local<JsString> {
         JsString::from_str(self, match value.ty() {
             JsType::Undefined => "undefined",
             JsType::Null => "object",
             JsType::Boolean => "boolean",
             JsType::Number => "number",
             JsType::String => "string",
-            JsType::Object => if value.unwrap_object(self).function().is_some() { "function" } else { "object" },
+            JsType::Object => if value.is_callable() { "function" } else { "object" },
             _ => panic!("unexpected type")
         })
     }
     
     // 11.8.5 The Abstract Relational Comparison Algorithm
-    pub fn compare(&mut self, x: Local<JsValue>, y: Local<JsValue>, left_first: bool) -> JsResult<ComparisonResult> {
+    pub fn compare(&mut self, x: JsValue, y: JsValue, left_first: bool) -> JsResult<ComparisonResult> {
         let px;
         let py;
         
@@ -300,12 +300,12 @@ impl JsEnv {
     }
     
     // 11.8.5 The Abstract Relational Comparison Algorithm
-    pub fn compare_string(&mut self, x: Local<JsValue>, y: Local<JsValue>) -> ComparisonResult {
+    pub fn compare_string(&mut self, x: JsValue, y: JsValue) -> ComparisonResult {
         assert_eq!(x.ty(), JsType::String);
         assert_eq!(y.ty(), JsType::String);
         
-        let x = x.unwrap_string(self);
-        let y = y.unwrap_string(self);
+        let x = x.unwrap_string();
+        let y = y.unwrap_string();
         
         let x = x.chars();
         let y = y.chars();
@@ -337,7 +337,7 @@ impl JsEnv {
     }
     
     // 11.8.1 The Less-than Operator ( < )
-    pub fn compare_lt(&mut self, lval: Local<JsValue>, rval: Local<JsValue>) -> JsResult<bool> {
+    pub fn compare_lt(&mut self, lval: JsValue, rval: JsValue) -> JsResult<bool> {
         let result = try!(self.compare(lval, rval, true));
         
         Ok(match result {
@@ -347,7 +347,7 @@ impl JsEnv {
     }
     
     // 11.8.2 The Greater-than Operator ( > )
-    pub fn compare_gt(&mut self, lval: Local<JsValue>, rval: Local<JsValue>) -> JsResult<bool>  {
+    pub fn compare_gt(&mut self, lval: JsValue, rval: JsValue) -> JsResult<bool>  {
         let result = try!(self.compare(rval, lval, false));
         
         Ok(match result {
@@ -357,7 +357,7 @@ impl JsEnv {
     }
     
     // 11.8.3 The Less-than-or-equal Operator ( <= )
-    pub fn compare_le(&mut self, lval: Local<JsValue>, rval: Local<JsValue>) -> JsResult<bool>  {
+    pub fn compare_le(&mut self, lval: JsValue, rval: JsValue) -> JsResult<bool>  {
         let result = try!(self.compare(rval, lval, false));
         
         Ok(match result {
@@ -367,7 +367,7 @@ impl JsEnv {
     }
     
     // 11.8.4 The Greater-than-or-equal Operator ( >= )
-    pub fn compare_ge(&mut self, lval: Local<JsValue>, rval: Local<JsValue>) -> JsResult<bool>  {
+    pub fn compare_ge(&mut self, lval: JsValue, rval: JsValue) -> JsResult<bool>  {
         let result = try!(self.compare(lval, rval, true));
         
         Ok(match result {
@@ -376,16 +376,16 @@ impl JsEnv {
         })
     }
     
-    pub fn new_function(&mut self, function_ref: FunctionRef, scope: Option<Local<JsScope>>, strict: bool) -> JsResult<Local<JsValue>> {
-        let mut result = JsObject::new_function(self, JsFunction::Ir(function_ref), strict).as_value(self);
+    pub fn new_function(&mut self, function_ref: FunctionRef, scope: Option<Local<JsScope>>, strict: bool) -> JsResult<JsValue> {
+        let mut result = JsObject::new_function(self, JsFunction::Ir(function_ref), strict).as_value();
         
         let function = self.ir.get_function(function_ref);
         if function.take_scope {
-            result.set_scope(self, scope);
+            result.set_scope(scope);
         }
         
         let mut proto = self.create_object();
-        let value = proto.as_value(self);
+        let value = proto.as_value();
         try!(result.define_own_property(self, name::PROTOTYPE, JsDescriptor::new_value(value, true, false, false), false));
         try!(proto.define_own_property(self, name::CONSTRUCTOR, JsDescriptor::new_value(result, true, false, true), false));
 
@@ -393,20 +393,20 @@ impl JsEnv {
     }
     
     // 11.8.6 The instanceof operator
-    pub fn instanceof(&mut self, lval: Local<JsValue>, rval: Local<JsValue>) -> JsResult<Local<JsValue>> {
+    pub fn instanceof(&mut self, lval: JsValue, rval: JsValue) -> JsResult<JsValue> {
         let result = try!(rval.has_instance(self, lval));
-        Ok(self.new_bool(result))
+        Ok(JsValue::new_bool(result))
     }
     
     // http://ecma-international.org/ecma-262/5.1/#sec-11.4.9
-    pub fn logical_not(&mut self, value: Local<JsValue>) -> Local<JsValue> {
+    pub fn logical_not(&mut self, value: JsValue) -> JsValue {
         let value = value.to_boolean();
-        self.new_bool(!value)
+        JsValue::new_bool(!value)
     }
     
     // 11.9.1 The Equals Operator ( == )
     // 11.9.3 The Abstract Equality Comparison Algorithm
-    pub fn eq(&mut self, lval: Local<JsValue>, rval: Local<JsValue>) -> JsResult<bool> {
+    pub fn eq(&mut self, lval: JsValue, rval: JsValue) -> JsResult<bool> {
         let lty = lval.ty();
         let rty = rval.ty();
         
@@ -419,19 +419,19 @@ impl JsEnv {
             Ok(true)
         } else if lty == JsType::Number && rty == JsType::String {
             let rval = try!(rval.to_number(self));
-            let rval = self.new_number(rval);
+            let rval = JsValue::new_number(rval);
             self.eq(lval, rval)
         } else if lty == JsType::String && rty == JsType::Number {
             let lval = try!(lval.to_number(self));
-            let lval = self.new_number(lval);
+            let lval = JsValue::new_number(lval);
             self.eq(lval, rval)
         } else if lty == JsType::Boolean {
             let lval = try!(lval.to_number(self));
-            let lval = self.new_number(lval);
+            let lval = JsValue::new_number(lval);
             self.eq(lval, rval)
         } else if rty == JsType::Boolean {
             let rval = try!(rval.to_number(self));
-            let rval = self.new_number(rval);
+            let rval = JsValue::new_number(rval);
             self.eq(lval, rval)
         } else if (lty == JsType::String || lty == JsType::Number) && rty == JsType::Object {
             let rval = try!(rval.to_primitive(self, JsPreferredType::None));
@@ -445,14 +445,14 @@ impl JsEnv {
     }
     
     // 11.9.2 The Does-not-equals Operator ( != )
-    pub fn ne(&mut self, lref: Local<JsValue>, rref: Local<JsValue>) -> JsResult<bool> {
+    pub fn ne(&mut self, lref: JsValue, rref: JsValue) -> JsResult<bool> {
         return Ok(!try!(self.eq(lref, rref)))
     } 
     
     // http://ecma-international.org/ecma-262/5.1/#sec-11.9.4
     // http://ecma-international.org/ecma-262/5.1/#sec-11.9.5
     // http://ecma-international.org/ecma-262/5.1/#sec-11.9.6
-    pub fn strict_eq(&mut self, lval: Local<JsValue>, rval: Local<JsValue>) -> bool {
+    pub fn strict_eq(&mut self, lval: JsValue, rval: JsValue) -> bool {
         if lval.ty() != rval.ty() {
             false
         } else {
@@ -470,8 +470,8 @@ impl JsEnv {
                     }
                 }
                 JsType::String => {
-                    let lval = lval.unwrap_string(self);
-                    let rval = rval.unwrap_string(self);
+                    let lval = lval.unwrap_string();
+                    let rval = rval.unwrap_string();
                     
                     let x = lval.chars();
                     let y = rval.chars();
@@ -497,8 +497,8 @@ impl JsEnv {
     pub fn create_object(&self) -> Local<JsObject> {
         let mut obj = JsObject::new_local(self, JsStoreType::Hash);
         
-        obj.set_prototype(self, Some(self.handle(JsHandle::Object).as_value(self)));
-        obj.set_class(self, Some(name::OBJECT_CLASS));
+        obj.set_prototype(Some(self.handle(JsHandle::Object).as_value()));
+        obj.set_class(Some(name::OBJECT_CLASS));
         
         obj
     }
@@ -512,7 +512,7 @@ impl JsEnv {
         // We don't propagate the JsError because this define_own_property
         // will not fail.
         
-        let length = self.new_number(0.0);
+        let length = JsValue::new_number(0.0);
         obj.define_own_property(
             self,
             name::LENGTH,
@@ -520,14 +520,14 @@ impl JsEnv {
             false
         ).ok();
         
-        obj.set_prototype(self, Some(self.handle(JsHandle::Array).as_value(self)));
-        obj.set_class(self, Some(name::ARRAY_CLASS));
+        obj.set_prototype(Some(self.handle(JsHandle::Array).as_value()));
+        obj.set_class(Some(name::ARRAY_CLASS));
         
         obj
     }
     
     // 9.12 The SameValue Algorithm
-    pub fn same_value(&self, x: Local<JsValue>, y: Local<JsValue>) -> bool {
+    pub fn same_value(&self, x: JsValue, y: JsValue) -> bool {
         let x_ty = x.ty();
         let y_ty = y.ty();
         
@@ -555,7 +555,7 @@ impl JsEnv {
                         false
                     }
                 }
-                JsType::String => JsString::equals(x.unwrap_string(self), y.unwrap_string(self)),
+                JsType::String => JsString::equals(x.unwrap_string(), y.unwrap_string()),
                 JsType::Boolean | JsType::Object => x == y,
                 _ => panic!("unexpected type")
             }
@@ -563,12 +563,12 @@ impl JsEnv {
     }
     
     // 10.6 Arguments Object
-    pub fn new_arguments(&mut self, args: &JsArgs, strict: bool) -> JsResult<Local<JsValue>> {
+    pub fn new_arguments(&mut self, args: &JsArgs, strict: bool) -> JsResult<JsValue> {
         let mut result = self.create_object();
         
-        result.set_class(self, Some(name::ARGUMENTS_CLASS));
+        result.set_class(Some(name::ARGUMENTS_CLASS));
         
-        let value = self.new_number(args.argc as f64);
+        let value = JsValue::new_number(args.argc as f64);
         try!(result.define_own_property(self, name::LENGTH, JsDescriptor::new_value(value, true, false, true), false));
         
         for i in 0..args.argc {
@@ -586,11 +586,11 @@ impl JsEnv {
             try!(result.define_own_property(self, name::CALLER, JsDescriptor::new_accessor(Some(thrower), Some(thrower), false, false), false));
         }
         
-        Ok(result.as_value(self))
+        Ok(result.as_value())
     }
     
     // 11.8.7 The in operator
-    pub fn in_(&mut self, lhs: Local<JsValue>, rhs: Local<JsValue>) -> JsResult<Local<JsValue>> {
+    pub fn in_(&mut self, lhs: JsValue, rhs: JsValue) -> JsResult<JsValue> {
         if rhs.ty() != JsType::Object {
             Err(JsError::new_type(self, ::errors::TYPE_IN_RHS_NOT_OBJECT))
         } else {
@@ -599,17 +599,17 @@ impl JsEnv {
             
             let result = rhs.has_property(self, name);
             
-            Ok(self.new_bool(result))
+            Ok(JsValue::new_bool(result))
         }
     }
     
     // 11.5.1 Applying the * Operator
-    pub fn multiply(&mut self, lhs: Local<JsValue>, rhs: Local<JsValue>) -> JsResult<f64> {
+    pub fn multiply(&mut self, lhs: JsValue, rhs: JsValue) -> JsResult<f64> {
         self.multiplicative(lhs, rhs, |lhs, rhs| lhs * rhs)
     }
     
     // 11.5.2 Applying the / Operator
-    pub fn divide(&mut self, lhs: Local<JsValue>, rhs: Local<JsValue>) -> JsResult<f64> {
+    pub fn divide(&mut self, lhs: JsValue, rhs: JsValue) -> JsResult<f64> {
         self.multiplicative(lhs, rhs, |lhs, rhs| {
             if rhs == 0.0 {
                 if lhs == 0.0 || lhs.is_nan() {
@@ -626,47 +626,47 @@ impl JsEnv {
     }
     
     // 11.5.3 Applying the % Operator
-    pub fn modulus(&mut self, lhs: Local<JsValue>, rhs: Local<JsValue>) -> JsResult<f64> {
+    pub fn modulus(&mut self, lhs: JsValue, rhs: JsValue) -> JsResult<f64> {
         self.multiplicative(lhs, rhs, |lhs, rhs| lhs % rhs)
     }
     
     // 11.5 Multiplicative Operators
-    fn multiplicative<F: FnOnce(f64, f64) -> f64>(&mut self, lhs: Local<JsValue>, rhs: Local<JsValue>, func: F) -> JsResult<f64> {
+    fn multiplicative<F: FnOnce(f64, f64) -> f64>(&mut self, lhs: JsValue, rhs: JsValue, func: F) -> JsResult<f64> {
         let left = try!(lhs.to_number(self));
         let right = try!(rhs.to_number(self));
         Ok(func(left, right))
     }
     
     // 11.10 Binary Bitwise Operators
-    pub fn bit_and(&mut self, lhs: Local<JsValue>, rhs: Local<JsValue>) -> JsResult<f64> {
+    pub fn bit_and(&mut self, lhs: JsValue, rhs: JsValue) -> JsResult<f64> {
         self.bitwise(lhs, rhs, |lhs, rhs| lhs & rhs)
     }
     
     // 11.10 Binary Bitwise Operators
-    pub fn bit_or(&mut self, lhs: Local<JsValue>, rhs: Local<JsValue>) -> JsResult<f64> {
+    pub fn bit_or(&mut self, lhs: JsValue, rhs: JsValue) -> JsResult<f64> {
         self.bitwise(lhs, rhs, |lhs, rhs| lhs | rhs)
     }
     
     // 11.10 Binary Bitwise Operators
-    pub fn bit_xor(&mut self, lhs: Local<JsValue>, rhs: Local<JsValue>) -> JsResult<f64> {
+    pub fn bit_xor(&mut self, lhs: JsValue, rhs: JsValue) -> JsResult<f64> {
         self.bitwise(lhs, rhs, |lhs, rhs| lhs ^ rhs)
     }
     
     // 11.10 Binary Bitwise Operators
-    fn bitwise<F: FnOnce(i32, i32) -> i32>(&mut self, lhs: Local<JsValue>, rhs: Local<JsValue>, func: F) -> JsResult<f64> {
+    fn bitwise<F: FnOnce(i32, i32) -> i32>(&mut self, lhs: JsValue, rhs: JsValue, func: F) -> JsResult<f64> {
         let left = try!(lhs.to_int32(self));
         let right = try!(rhs.to_int32(self));
         Ok(func(left, right) as f64)
     }
     
     // 11.4.8 Bitwise NOT Operator ( ~ )
-    pub fn bit_not(&mut self, arg: Local<JsValue>) -> JsResult<f64> {
+    pub fn bit_not(&mut self, arg: JsValue) -> JsResult<f64> {
         let arg = try!(arg.to_int32(self));
         Ok((!arg) as f64)
     }
     
     // 11.7.1 The Left Shift Operator ( << )
-    pub fn lsh(&mut self, lhs: Local<JsValue>, rhs: Local<JsValue>) -> JsResult<f64> {
+    pub fn lsh(&mut self, lhs: JsValue, rhs: JsValue) -> JsResult<f64> {
         let lnum = try!(lhs.to_int32(self));
         let rnum = try!(rhs.to_uint32(self));
         let shift_count = rnum & 0x1f;
@@ -675,7 +675,7 @@ impl JsEnv {
     }
     
     // 11.7.2 The Signed Right Shift Operator ( >> )
-    pub fn rsh(&mut self, lhs: Local<JsValue>, rhs: Local<JsValue>) -> JsResult<f64> {
+    pub fn rsh(&mut self, lhs: JsValue, rhs: JsValue) -> JsResult<f64> {
         let lnum = try!(lhs.to_int32(self));
         let rnum = try!(rhs.to_uint32(self));
         let shift_count = rnum & 0x1f;
@@ -684,7 +684,7 @@ impl JsEnv {
     }
     
     // 11.7.3 The Unsigned Right Shift Operator ( >>> )
-    pub fn unsigned_rsh(&mut self, lhs: Local<JsValue>, rhs: Local<JsValue>) -> JsResult<f64> {
+    pub fn unsigned_rsh(&mut self, lhs: JsValue, rhs: JsValue) -> JsResult<f64> {
         let lnum = try!(lhs.to_uint32(self));
         let rnum = try!(rhs.to_uint32(self));
         let shift_count = rnum & 0x1f;
@@ -693,6 +693,6 @@ impl JsEnv {
     }
 }
 
-fn throw_type_error(env: &mut JsEnv, _mode: JsFnMode, _args: JsArgs) -> JsResult<Local<JsValue>> {
+fn throw_type_error(env: &mut JsEnv, _mode: JsFnMode, _args: JsArgs) -> JsResult<JsValue> {
     Err(JsError::new_type(env, ::errors::TYPE_CANNOT_ACCESS_ARGUMENTS_PROPERTY))
 }

--- a/src/rt/scope.rs
+++ b/src/rt/scope.rs
@@ -1,9 +1,9 @@
-use rt::{JsEnv, JsValue, JsObject, JsItem, GC_SCOPE, GC_VALUE};
+use rt::{JsEnv, JsRawValue, JsValue, JsObject, JsItem, GC_SCOPE, GC_VALUE};
 use gc::*;
 
 // Modifications to this struct must be synchronized with the GC walker.
 pub struct JsScope {
-    items: Array<JsValue>
+    items: Array<JsRawValue>
 }
 
 impl JsScope {
@@ -15,7 +15,7 @@ impl JsScope {
         }
         
         if let Some(parent) = parent {
-            result.raw_set(0, parent.as_value(env));
+            result.raw_set(0, parent.as_value());
         }
         
         result
@@ -31,30 +31,30 @@ impl JsScope {
         }
         
         if let Some(parent) = parent {
-            result.raw_set(0, parent.as_value(env));
+            result.raw_set(0, parent.as_value());
         }
-        result.raw_set(1, scope_object.as_value(env));
+        result.raw_set(1, scope_object.as_value());
         
         result
     }
 }
 
 impl Local<JsScope> {
-    pub fn as_value(&self, env: &JsEnv) -> Local<JsValue> {
-        env.new_scope(*self)
+    pub fn as_value(&self) -> JsValue {
+        JsValue::new_scope(*self)
     }
     
     pub fn parent(&self, env: &JsEnv) -> Option<Local<JsScope>> {
         let parent = self.raw_get(env, 0);
         
-        if parent.is_undefined() { None } else { Some(parent.unwrap_scope(env)) }
+        if parent.is_undefined() { None } else { Some(parent.unwrap_scope()) }
     }
     
     pub fn scope_object(&self, env: &JsEnv) -> Local<JsObject> {
-        self.raw_get(env, 1).unwrap_object(env)
+        self.raw_get(env, 1).unwrap_object()
     }
     
-    pub fn arguments(&self, env: &JsEnv) -> Option<Local<JsValue>> {
+    pub fn arguments(&self, env: &JsEnv) -> Option<JsValue> {
         if self.items.len() == 2 {
             None
         } else {
@@ -62,7 +62,7 @@ impl Local<JsScope> {
         }
     }
     
-    pub fn set_arguments(&mut self, arguments: Local<JsValue>) {
+    pub fn set_arguments(&mut self, arguments: JsValue) {
         if self.items.len() == 2 {
             panic!("scope does not have a slot to store arguments");
         }
@@ -74,23 +74,19 @@ impl Local<JsScope> {
         self.items.len() - 1
     }
     
-    pub fn get(&self, env: &JsEnv, index: usize) -> Local<JsValue> {
+    pub fn get(&self, env: &JsEnv, index: usize) -> JsValue {
         self.raw_get(env, index + 1)
     }
     
-    pub fn set(&mut self, index: usize, value: Local<JsValue>) {
+    pub fn set(&mut self, index: usize, value: JsValue) {
         self.raw_set(index + 1, value)
     }
     
-    fn raw_get(&self, env: &JsEnv, index: usize) -> Local<JsValue> {
-        let mut local = env.new_value();
-        
-        *local = self.items[index];
-        
-        local
+    fn raw_get(&self, env: &JsEnv, index: usize) -> JsValue {
+        self.items[index].as_value(env)
     }
     
-    fn raw_set(&mut self, index: usize, value: Local<JsValue>) {
-        self.items[index] = *value;
+    fn raw_set(&mut self, index: usize, value: JsValue) {
+        self.items[index] = value.as_raw();
     }
 }

--- a/src/rt/string.rs
+++ b/src/rt/string.rs
@@ -111,23 +111,23 @@ impl JsString {
 }
 
 impl JsItem for Local<JsString> {
-    fn as_value(&self, env: &JsEnv) -> Local<JsValue> {
-        env.new_string(*self)
+    fn as_value(&self) -> JsValue {
+        JsValue::new_string(*self)
     }
     
-    fn has_prototype(&self, _: &JsEnv) -> bool {
+    fn has_prototype(&self) -> bool {
         true
     }
     
-    fn prototype(&self, env: &JsEnv) -> Option<Local<JsValue>> {
-        Some(env.handle(JsHandle::String).as_value(env))
+    fn prototype(&self, env: &JsEnv) -> Option<JsValue> {
+        Some(env.handle(JsHandle::String).as_value())
     }
     
     // 15.5.5.2 [[GetOwnProperty]] ( P )
     // 15.5.5.1 length
     fn get_own_property(&self, env: &JsEnv, property: Name) -> Option<JsDescriptor> {
         if property == name::LENGTH {
-            let value = env.new_number(self.chars.len() as f64);
+            let value = JsValue::new_number(self.chars.len() as f64);
             return Some(JsDescriptor::new_value(value, false, false, false));
         }
         
@@ -137,7 +137,7 @@ impl JsItem for Local<JsString> {
                 let char = chars[index];
                 let mut string = JsString::new_local(env, 1);
                 string.chars[0] = char;
-                return Some(JsDescriptor::new_value(string.as_value(env), false, true, false));
+                return Some(JsDescriptor::new_value(string.as_value(), false, true, false));
             }
         }
         

--- a/src/rt/undefined.rs
+++ b/src/rt/undefined.rs
@@ -1,20 +1,19 @@
 use rt::{JsItem, JsEnv, JsValue, JsDescriptor};
-use gc::Local;
 use ::{JsResult, JsError};
 use syntax::Name;
 
 pub struct JsUndefined;
 
 impl JsItem for JsUndefined {
-    fn as_value(&self, env: &JsEnv) -> Local<JsValue> {
-        env.new_undefined()
+    fn as_value(&self) -> JsValue {
+        JsValue::new_undefined()
     }
     
     fn get_property(&self, _: &JsEnv, _: Name) -> Option<JsDescriptor> {
         None
     }
     
-    fn get(&self, env: &mut JsEnv, _: Name) -> JsResult<Local<JsValue>> {
+    fn get(&self, env: &mut JsEnv, _: Name) -> JsResult<JsValue> {
         Err(JsError::new_type(env, ::errors::TYPE_UNDEFINED))
     }
     
@@ -22,7 +21,7 @@ impl JsItem for JsUndefined {
         panic!("not supported");
     }
     
-    fn put(&mut self, env: &mut JsEnv, _: Name, _: Local<JsValue>, _: bool) -> JsResult<()> {
+    fn put(&mut self, env: &mut JsEnv, _: Name, _: JsValue, _: bool) -> JsResult<()> {
         Err(JsError::new_type(env, ::errors::TYPE_UNDEFINED))
     }
     

--- a/src/rt/value.rs
+++ b/src/rt/value.rs
@@ -36,6 +36,7 @@ const DOUBLE_EXPONENT_BITS    : u64 = 0x7ff0000000000000u64;
 const DOUBLE_SIGNIFICANT_BITS : u64 = 0x000fffffffffffffu64;
 
 #[derive(Copy, Clone, PartialEq)]
+#[repr(C)]
 pub struct JsValue {
     ty: JsType,
     value: JsRawValue

--- a/src/rt/value.rs
+++ b/src/rt/value.rs
@@ -737,6 +737,8 @@ pub unsafe fn validate_walker_for_value(walker: &GcWalker) {
     let ptr = transmute::<_, ptr_t>(&*object);
     
     validate_walker_for_embedded_value(walker, ptr, GC_VALUE, 0, &mut *object);
+    
+    assert_eq!(size_of::<JsValue>(), 16);
 }
 
 pub unsafe fn validate_walker_for_embedded_value(walker: &GcWalker, ptr: ptr_t, ty: u32, offset: u32, object: *mut JsValue) {

--- a/src/rt/walker.rs
+++ b/src/rt/walker.rs
@@ -1,5 +1,5 @@
 use gc::{GcWalker, GcWalk, GcFinalize, GcRootWalker, ptr_t};
-use rt::{JsType, JsRegExp};
+use rt::{JsType, JsRegExp, JsObject};
 use rt::{GC_ARRAY_STORE, GC_ENTRY, GC_HASH_STORE, GC_ITERATOR, GC_OBJECT, GC_REGEXP};
 use rt::{GC_SCOPE, GC_STRING, GC_U16, GC_U32, GC_VALUE, GC_SPARSE_ARRAY, GC_ARRAY_CHUNK};
 use rt::stack::Stack;
@@ -59,7 +59,7 @@ impl GcWalker for Walker {
                 GC_OBJECT => {
                     match index {
                         3 if is_value_ptr(ptr, 2) => GcWalk::Pointer,
-                        11 | 12 | 14 => GcWalk::Pointer,
+                        6 | 7 | 9 => GcWalk::Pointer,
                         _ => GcWalk::Skip
                     }
                 }
@@ -116,6 +116,12 @@ impl GcWalker for Walker {
                 GC_REGEXP => {
                     let regex = transmute::<_, *mut JsRegExp>(ptr);
                     (&mut *regex).finalize();
+                    
+                    GcFinalize::Finalized
+                }
+                GC_OBJECT => {
+                    let object = transmute::<_, *mut JsObject>(ptr);
+                    (&mut *object).finalize();
                     
                     GcFinalize::Finalized
                 }

--- a/src/rt/walker.rs
+++ b/src/rt/walker.rs
@@ -59,7 +59,7 @@ impl GcWalker for Walker {
                 GC_OBJECT => {
                     match index {
                         3 if is_value_ptr(ptr, 2) => GcWalk::Pointer,
-                        12 | 13 | 15 => GcWalk::Pointer,
+                        11 | 12 | 14 => GcWalk::Pointer,
                         _ => GcWalk::Skip
                     }
                 }

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -2,7 +2,7 @@ use util::interner::StrInterner;
 use util::interner::RcStr;
 use std::fmt;
 use std::ops::Deref;
-use std::{i32, u32};
+use std::{i32, u32, i64};
 
 pub mod reader;
 pub mod lexer;
@@ -40,6 +40,8 @@ impl Span {
         }
     }
 }
+
+pub const INVALID_NAME : Name = Name(i64::MAX);
 
 #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Clone, Copy, Debug)]
 pub struct Name(i64);


### PR DESCRIPTION
Memory usage has been improved in a lot of places:
- `JsFn` is now a pointer instead of a closure (saves a word);
- The details of `JsFunction` has been moved out of `JsObject` into a native box;
- `JsObject::class` is not an `Option<T>` anymore. Instead a magic value is used to mark it as empty;
- Almost all of the `JsValue` allocations have been removed by creating a `JsValue` version that embeds a `Local<T>` (i.e. rooted pointer).
